### PR TITLE
Remove code coverage in phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,15 +17,6 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./app</directory>
-        </include>
-        <exclude>
-              <file>./app/Clients/Forge.php</file>
-              <file>./app/Support/Time.php</file>
-        </exclude>
-    </coverage>
     <php>
         <env name="APP_ENV" value="testing"/>
     </php>


### PR DESCRIPTION
We don't use code coverage atm. None of our other packages have this section.