### PR TITLE
Rename argument "--tail" to "--follow"

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You may also view logs directly from the command-line. To do so, use the `{resou
 
 ```bash
 forge daemon:logs
-forge daemon:logs --tail # Visualize logs in realtime
+forge daemon:logs --follow # Visualize logs in realtime
 
 forge database:logs
 

--- a/app/Commands/Concerns/InteractsWithLogs.php
+++ b/app/Commands/Concerns/InteractsWithLogs.php
@@ -25,10 +25,10 @@ trait InteractsWithLogs
      * Shows the given site logs.
      *
      * @param  \Laravel\Forge\Resources\Site  $site
-     * @param  bool  $tail
+     * @param  bool  $follow
      * @return void
      */
-    protected function showSiteLogs($site, $tail)
+    protected function showSiteLogs($site, $follow)
     {
         $this->step('Retrieving the latest site logs');
 
@@ -49,7 +49,7 @@ trait InteractsWithLogs
 
         $this->showRemoteLogs(collect($files)->map(function ($file) use ($sitePath) {
             return $sitePath.'/'.$file;
-        })->all(), $tail);
+        })->all(), $follow);
     }
 
     /**
@@ -57,32 +57,32 @@ trait InteractsWithLogs
      *
      * @param  string|int  $daemonId
      * @param  string  $username
-     * @param  bool  $tail
+     * @param  bool  $follow
      * @return void
      */
-    protected function showDaemonLogs($daemonId, $username, $tail)
+    protected function showDaemonLogs($daemonId, $username, $follow)
     {
         abort_if($username == 'root', 1, 'Requesting logs from daemons run by [root] is not supported.');
 
         $this->step('Retrieving the latest daemon logs');
 
-        $this->showRemoteLogs('/home/'.$username.'/.forge/daemon-'.$daemonId.'.log', $tail);
+        $this->showRemoteLogs('/home/'.$username.'/.forge/daemon-'.$daemonId.'.log', $follow);
     }
 
     /**
      * Shows remote logs.
      *
      * @param  array|string  $files
-     * @param  bool  $tail
+     * @param  bool  $follow
      * @return void
      */
-    protected function showRemoteLogs($files, $tail)
+    protected function showRemoteLogs($files, $follow)
     {
         $this->newLine();
 
         [$exitCode, $output] = $this->remote->tail($files, function ($output) {
             $this->displayLogs($output);
-        }, $tail ? ['-f'] : []);
+        }, $follow ? ['-f'] : []);
 
         abort_if(
             empty($output) || ($exitCode > 0 && $exitCode < 255),

--- a/app/Commands/DaemonLogsCommand.php
+++ b/app/Commands/DaemonLogsCommand.php
@@ -12,7 +12,7 @@ class DaemonLogsCommand extends Command
      * @var string
      */
     protected $signature = 'daemon:logs {daemon? : The daemon ID}
-    `                                   {--tail : Monitor the log changes in realtime}';
+    `                                   {--f|follow : Monitor the log changes in realtime}';
 
     /**
      * The description of the command.
@@ -32,6 +32,6 @@ class DaemonLogsCommand extends Command
 
         $daemon = $this->forge->daemon($this->currentServer()->id, $daemonId);
 
-        $this->showDaemonLogs($daemon->id, $daemon->user, $this->option('tail'));
+        $this->showDaemonLogs($daemon->id, $daemon->user, $this->option('follow'));
     }
 }

--- a/app/Commands/SiteLogsCommand.php
+++ b/app/Commands/SiteLogsCommand.php
@@ -12,7 +12,7 @@ class SiteLogsCommand extends Command
      * @var string
      */
     protected $signature = 'site:logs {site? : The site name}
-                                      {--tail : Monitor the log changes in realtime}';
+                                      {--f|follow : Monitor the log changes in realtime}';
 
     /**
      * The description of the command.
@@ -32,6 +32,6 @@ class SiteLogsCommand extends Command
 
         $site = $this->forge->site($this->currentServer()->id, $siteId);
 
-        $this->showSiteLogs($site, $this->option('tail'));
+        $this->showSiteLogs($site, $this->option('follow'));
     }
 }

--- a/tests/Feature/DaemonLogsCommandTest.php
+++ b/tests/Feature/DaemonLogsCommandTest.php
@@ -48,7 +48,7 @@ it('can tail logs from daemons', function () {
             '[00:02] BAR',
         ]]);
 
-    $this->artisan('daemon:logs', ['--tail' => true])
+    $this->artisan('daemon:logs', ['--follow' => true])
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Daemon Would You Like To Retrieve The Logs From</>', 1);
 });
 
@@ -74,7 +74,7 @@ it('exits with 0 exit code on control + c', function () {
             '[00:02] BAR',
         ]]);
 
-    $this->artisan('daemon:logs', ['--tail' => true])
+    $this->artisan('daemon:logs', ['--follow' => true])
         ->assertExitCode(0)
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Daemon Would You Like To Retrieve The Logs From</>', 1);
 });
@@ -98,7 +98,7 @@ it('displays errors', function () {
         ->with('/home/forge/.forge/daemon-1.log', Mockery::type(Closure::class), ['-f'])
         ->andReturn(1);
 
-    $this->artisan('daemon:logs', ['--tail' => true])
+    $this->artisan('daemon:logs', ['--follow' => true])
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Daemon Would You Like To Retrieve The Logs From</>', 1);
 })->throws('The requested logs could not be found or they are empty.');
 

--- a/tests/Feature/SiteLogsCommandTest.php
+++ b/tests/Feature/SiteLogsCommandTest.php
@@ -58,7 +58,7 @@ it('can tail logs from sites', function () {
             '[00:02] BAR',
         ]]);
 
-    $this->artisan('site:logs', ['--tail' => true])
+    $this->artisan('site:logs', ['--follow' => true])
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Site Would You Like To Retrieve The Logs From</>', 1);
 });
 
@@ -89,7 +89,7 @@ it('exits with 0 exit code on control + c', function () {
             '[00:02] BAR',
         ]]);
 
-    $this->artisan('site:logs', ['--tail' => true])
+    $this->artisan('site:logs', ['--follow' => true])
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Site Would You Like To Retrieve The Logs From</>', 1);
 });
 
@@ -119,6 +119,6 @@ it('displays errors', function () {
             'ls: error',
         ]]);
 
-    $this->artisan('site:logs', ['--tail' => true])
+    $this->artisan('site:logs', ['--follow' => true])
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Site Would You Like To Retrieve The Logs From</>', 2);
 })->throws('The requested logs could not be found or they are empty.');


### PR DESCRIPTION
To follow the naming of `tail` I think `tail` should be  renamed as `--follow` with `-f` as a shorthand.
What do you think?