### PR TITLE
Automatically select when answers contains one item

### DIFF
--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -51,7 +51,7 @@ trait InteractsWithIO
         }
 
         if ($answers->containsOneItem()) {
-            $this->step('Selected [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->name);
+            $this->step('Selected site [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->name);
 
             return $answers->first()->id;
         }
@@ -78,7 +78,7 @@ trait InteractsWithIO
         }
 
         if ($answers->containsOneItem()) {
-            $this->step('Selected [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->name);
+            $this->step('Selected server [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->name);
 
             return $answers->first()->id;
         }
@@ -105,7 +105,7 @@ trait InteractsWithIO
         }
 
         if ($answers->containsOneItem()) {
-            $this->step('Selected [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->command);
+            $this->step('Selected daemon [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->command);
 
             return $answers->first()->id;
         }

--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -51,7 +51,7 @@ trait InteractsWithIO
         }
 
         if ($answers->containsOneItem()) {
-            $this->step('Selected [<comment>'. $answers->first()->id .'</comment>] '. $answers->first()->name);
+            $this->step('Selected [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->name);
 
             return $answers->first()->id;
         }
@@ -78,7 +78,7 @@ trait InteractsWithIO
         }
 
         if ($answers->containsOneItem()) {
-            $this->step('Selected [<comment>'. $answers->first()->id .'</comment>] '. $answers->first()->name);
+            $this->step('Selected [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->name);
 
             return $answers->first()->id;
         }
@@ -105,7 +105,7 @@ trait InteractsWithIO
         }
 
         if ($answers->containsOneItem()) {
-            $this->step('Selected [<comment>'. $answers->first()->id .'</comment>] '. $answers->first()->command);
+            $this->step('Selected [<comment>'.$answers->first()->id.'</comment>] '.$answers->first()->command);
 
             return $answers->first()->id;
         }

--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -50,6 +50,12 @@ trait InteractsWithIO
             return optional($answers->where('name', $name)->first())->id ?: $name;
         }
 
+        if ($answers->containsOneItem()) {
+            $this->step('Selected [<comment>'. $answers->first()->id .'</comment>] '. $answers->first()->name);
+
+            return $answers->first()->id;
+        }
+
         return $this->choiceStep($question, $answers->mapWithKeys(function ($resource) {
             return [$resource->id => $resource->name];
         })->all());
@@ -71,6 +77,12 @@ trait InteractsWithIO
             return optional($answers->where('name', $name)->first())->id ?: $name;
         }
 
+        if ($answers->containsOneItem()) {
+            $this->step('Selected [<comment>'. $answers->first()->id .'</comment>] '. $answers->first()->name);
+
+            return $answers->first()->id;
+        }
+
         return $this->choiceStep($question, $answers->mapWithKeys(function ($resource) {
             return [$resource->id => $resource->name];
         })->all());
@@ -90,6 +102,12 @@ trait InteractsWithIO
 
         if (! is_null($command)) {
             return optional($answers->where('command', $command)->first())->id ?: $command;
+        }
+
+        if ($answers->containsOneItem()) {
+            $this->step('Selected [<comment>'. $answers->first()->id .'</comment>] '. $answers->first()->command);
+
+            return $answers->first()->id;
         }
 
         return $this->choiceStep($question, $answers->mapWithKeys(function ($resource) {


### PR DESCRIPTION
`askForSite()`, `askForServer()` and `askForDaemon()` will not prompt the user to select when only one answer exist. This prevents asking an obvious question when no other option are available.