### PR TITLE
Avoids attempt to question when there is no answers available

### DIFF
--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -46,6 +46,8 @@ trait InteractsWithIO
 
         $answers = collect($this->forge->sites($this->currentServer()->id));
 
+        abort_if($answers->isEmpty(), 1, 'The server does not have any sites.');
+
         if (! is_null($name)) {
             return optional($answers->where('name', $name)->first())->id ?: $name;
         }
@@ -67,6 +69,8 @@ trait InteractsWithIO
 
         $answers = collect($this->forge->servers());
 
+        abort_if($answers->isEmpty(), 1, 'The account does not have any servers.');
+
         if (! is_null($name)) {
             return optional($answers->where('name', $name)->first())->id ?: $name;
         }
@@ -87,6 +91,8 @@ trait InteractsWithIO
         $command = $this->argument('daemon');
 
         $answers = collect($this->forge->daemons($this->currentServer()->id));
+
+        abort_if($answers->isEmpty(), 1, 'The server does not have any daemons.');
 
         if (! is_null($command)) {
             return optional($answers->where('command', $command)->first())->id ?: $command;

--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -46,7 +46,7 @@ trait InteractsWithIO
 
         $answers = collect($this->forge->sites($this->currentServer()->id));
 
-        abort_if($answers->isEmpty(), 1, 'The server does not have any sites.');
+        abort_if($answers->isEmpty(), 1, 'This server does not have any sites.');
 
         if (! is_null($name)) {
             return optional($answers->where('name', $name)->first())->id ?: $name;
@@ -69,7 +69,7 @@ trait InteractsWithIO
 
         $answers = collect($this->forge->servers());
 
-        abort_if($answers->isEmpty(), 1, 'The account does not have any servers.');
+        abort_if($answers->isEmpty(), 1, 'This account does not have any servers.');
 
         if (! is_null($name)) {
             return optional($answers->where('name', $name)->first())->id ?: $name;
@@ -92,7 +92,7 @@ trait InteractsWithIO
 
         $answers = collect($this->forge->daemons($this->currentServer()->id));
 
-        abort_if($answers->isEmpty(), 1, 'The server does not have any daemons.');
+        abort_if($answers->isEmpty(), 1, 'This server does not have any daemons.');
 
         if (! is_null($command)) {
             return optional($answers->where('command', $command)->first())->id ?: $command;


### PR DESCRIPTION
This pull request avoids the attempt to question the user when there is no answers available. This avoids a runtime exception when the user uses commands such as `servers:switch`, `daemon:restart`, etc.

Fixes #32 