### PR TITLE
Add support for displaying tags on site and server command output

### DIFF
--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -76,7 +76,9 @@ trait InteractsWithIO
         }
 
         return $this->choiceStep($question, $answers->mapWithKeys(function ($resource) {
-            return [$resource->id => $resource->name];
+            $tags = ! empty($resource->tags) ? " ({$resource->tags()})" : null;
+
+            return [$resource->id => $resource->name.$tags];
         })->all());
     }
 

--- a/app/Commands/ServerCurrentCommand.php
+++ b/app/Commands/ServerCurrentCommand.php
@@ -34,12 +34,15 @@ class ServerCurrentCommand extends Command
      */
     public function handle()
     {
+        /** @var  \Laravel\Forge\Resources\Server  $server */
         $server = $this->forge->server(
             $this->config->get('server')
         );
 
+        $tags = ! empty($server->tags) ? " ({$server->tags(',')})" : null;
+
         $this->successfulStep(
-            'You are currently within the <comment>['.$server->name.']</comment> server context.'
+            'You are currently within the <comment>['.$server->name.']'.$tags.'</comment> server context.'
         );
     }
 }

--- a/app/Commands/ServerListCommand.php
+++ b/app/Commands/ServerListCommand.php
@@ -28,12 +28,13 @@ class ServerListCommand extends Command
         $this->step('Retrieving the list of servers');
 
         $this->table([
-            'ID', 'Name', 'IP Address',
+            'ID', 'Name', 'IP Address', 'Tags',
         ], collect($this->forge->servers())->map(function ($server) {
             return [
                 $server->id,
                 $server->name,
                 $server->ipAddress,
+                $server->tags(),
             ];
         })->all());
     }

--- a/app/Commands/SiteListCommand.php
+++ b/app/Commands/SiteListCommand.php
@@ -34,12 +34,13 @@ class SiteListCommand extends Command
         );
 
         $this->table([
-            'ID', 'Name', 'PHP',
+            'ID', 'Name', 'PHP', 'Tags',
         ], collect($sites)->map(function ($site) {
             return [
                 $site->id,
                 $site->name,
                 $site->phpVersion ? PhpVersion::of($site->phpVersion)->release() : 'None',
+                $site->tags(),
             ];
         })->all());
     }

--- a/tests/Feature/CommandTest.php
+++ b/tests/Feature/CommandTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use App\Commands\Command;
+use Laravel\Forge\Resources\Server;
 
 beforeEach(function () {
     $this->client->shouldReceive('servers')->andReturn([
-        (object) ['id' => 1, 'name' => 'production', 'ipAddress' => '123.456.789.000'],
+        new Server(['id' => 1, 'name' => 'production', 'ipAddress' => '123.456.789.000']),
     ]);
 });
 

--- a/tests/Feature/ServerCurrentCommandTest.php
+++ b/tests/Feature/ServerCurrentCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Laravel\Forge\Exceptions\NotFoundException;
+use Laravel\Forge\Resources\Server;
 
 it('gets current server', function () {
     $this->client->shouldReceive('server')->with(1)->andReturn((object) [
@@ -11,6 +12,30 @@ it('gets current server', function () {
 
     $this->artisan('server:current')
         ->expectsOutput('==> You Are Currently Within The [production] Server Context.');
+});
+
+it('gets current server with tags if present', function () {
+    $this->client->shouldReceive('server')->with(1)->andReturn(new Server([
+        'name' => 'production',
+        'tags' => [['name' => 'first']],
+    ]));
+
+    $this->config->set('server', 1);
+
+    $this->artisan('server:current')
+        ->expectsOutput('==> You Are Currently Within The [production] (first) Server Context.');
+});
+
+it('gets current server with multiple tags if present', function () {
+    $this->client->shouldReceive('server')->with(1)->andReturn(new Server([
+        'name' => 'production',
+        'tags' => [['name' => 'first'], ['name' => 'second']],
+    ]));
+
+    $this->config->set('server', 1);
+
+    $this->artisan('server:current')
+        ->expectsOutput('==> You Are Currently Within The [production] (first,second) Server Context.');
 });
 
 it('may fail if current server no longer exists', function () {

--- a/tests/Feature/ServerListCommandTest.php
+++ b/tests/Feature/ServerListCommandTest.php
@@ -1,14 +1,18 @@
 <?php
 
+use Laravel\Forge\Resources\Server;
+
 it('displays the list of servers', function () {
     $this->client->shouldReceive('servers')->andReturn([
-        (object) ['id' => 1, 'name' => 'production', 'ipAddress' => '123.456.789.000'],
-        (object) ['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111'],
+        new Server(['id' => 1, 'name' => 'production', 'ipAddress' => '123.456.789.000', 'tags' => [['name' => 'first'], ['name' => 'second']]]),
+        new Server(['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111', 'tags' => []]),
+        new Server(['id' => 3, 'name' => 'acceptance', 'ipAddress' => '222.345.666.789', 'tags' => [['name' => 'first']]]),
     ]);
 
     $this->artisan('server:list')
-        ->expectsTable(['   ID', '   Name', '   IP Address'], [
-            ['id' => '   1', 'name' => '   production', 'ipAddress' => '   123.456.789.000'],
-            ['id' => '   2', 'name' => '   staging', 'ipAddress' => '   789.456.123.111'],
+        ->expectsTable(['   ID', '   Name', '   IP Address', '   Tags'], [
+            ['id' => '   1', 'name' => '   production', 'ipAddress' => '   123.456.789.000', 'tags' => '   first, second'],
+            ['id' => '   2', 'name' => '   staging', 'ipAddress' => '   789.456.123.111', 'tags' => '   '],
+            ['id' => '   3', 'name' => '   acceptance', 'ipAddress' => '   222.345.666.789', 'tags' => '   first'],
         ], 'compact');
 });

--- a/tests/Feature/ServerSwitchCommandTest.php
+++ b/tests/Feature/ServerSwitchCommandTest.php
@@ -1,13 +1,15 @@
 <?php
 
+use Laravel\Forge\Resources\Server;
+
 it('allows to switch the server context with an menu', function () {
     $this->client->shouldReceive('servers')->andReturn([
-        (object) ['id' => 1, 'name' => 'production', 'ipAddress' => '123.456.789.000'],
-        (object) ['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111'],
+        new Server(['id' => 1, 'name' => 'production', 'ipAddress' => '123.456.789.000', 'tags' => []]),
+        new Server(['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111', 'tags' => [['name' => 'selected']]]),
     ]);
 
     $this->client->shouldReceive('server')->andReturn(
-        (object) ['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111'],
+        new Server(['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111', 'tags' => [['name' => 'selected']]]),
     );
 
     $this->artisan('server:switch')
@@ -19,12 +21,12 @@ it('allows to switch the server context with an menu', function () {
 
 it('allows to switch the server context with an option', function () {
     $this->client->shouldReceive('server')->andReturn(
-        (object) ['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111'],
+        new Server(['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111']),
     );
 
     $this->client->shouldReceive('servers')->andReturn([
-        (object) ['id' => 1, 'name' => 'production', 'ipAddress' => '123.456.789.000'],
-        (object) ['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111'],
+        new Server(['id' => 1, 'name' => 'production', 'ipAddress' => '123.456.789.000', 'tags' => []]),
+        new Server(['id' => 2, 'name' => 'staging', 'ipAddress' => '789.456.123.111', 'tags' => [['name' => 'selected']]]),
     ]);
 
     $this->artisan('server:switch', ['server' => 'staging'])

--- a/tests/Feature/SiteListCommandTest.php
+++ b/tests/Feature/SiteListCommandTest.php
@@ -1,19 +1,23 @@
 <?php
 
+use Laravel\Forge\Resources\Site;
+
 it('can display the list of sites', function () {
     $this->client->shouldReceive('server')->andReturn(
         (object) ['id' => 1],
     );
 
     $this->client->shouldReceive('sites')->andReturn([
-        (object) ['id' => 1, 'name' => 'production.com', 'phpVersion' => 'php56'],
-        (object) ['id' => 2, 'name' => 'staging.com', 'phpVersion' => null],
+        new Site(['id' => 1, 'name' => 'production.com', 'phpVersion' => 'php56', 'tags' => [['name' => 'production'], ['name' => 'php 5.6']]]),
+        new Site(['id' => 2, 'name' => 'staging.com', 'phpVersion' => null, 'tags' => []]),
+        new Site(['id' => 3, 'name' => 'acceptance.com', 'phpVersion' => null, 'tags' => [['name' => 'acceptance']]]),
     ]);
 
     $this->artisan('site:list')
-        ->expectsTable(['   ID', '   Name', '   PHP'], [
-            ['id' => '   1', 'name' => '   production.com', 'phpVersion' => '   5.6'],
-            ['id' => '   2', 'name' => '   staging.com', 'phpVersion' => '   None'],
+        ->expectsTable(['   ID', '   Name', '   PHP', '   Tags'], [
+            ['id' => '   1', 'name' => '   production.com', 'phpVersion' => '   5.6', 'tags' => '   production, php 5.6'],
+            ['id' => '   2', 'name' => '   staging.com', 'phpVersion' => '   None', 'tags' => '   '],
+            ['id' => '   3', 'name' => '   acceptance.com', 'phpVersion' => '   None', 'tags' => '   acceptance'],
         ], 'compact');
 });
 
@@ -23,16 +27,16 @@ it('do not display archived servers', function () {
     );
 
     $this->client->shouldReceive('sites')->andReturn([
-        (object) ['id' => 1, 'name' => 'production.com', 'phpVersion' => 'php56'],
-        (object) ['id' => 2, 'name' => 'staging.com', 'phpVersion' => null],
-        (object) ['id' => 3, 'name' => 'archived.com', 'phpVersion' => 'php80', 'revoked' => true],
-        (object) ['id' => 4, 'name' => 'non-archived.com', 'phpVersion' => null, 'revoked' => false],
+        new Site(['id' => 1, 'name' => 'production.com', 'phpVersion' => 'php56']),
+        new Site(['id' => 2, 'name' => 'staging.com', 'phpVersion' => null]),
+        new Site(['id' => 3, 'name' => 'archived.com', 'phpVersion' => 'php80', 'revoked' => true]),
+        new Site(['id' => 4, 'name' => 'non-archived.com', 'phpVersion' => null, 'revoked' => false]),
     ]);
 
     $this->artisan('site:list')
-        ->expectsTable(['   ID', '   Name', '   PHP'], [
-            ['id' => '   1', 'name' => '   production.com', 'phpVersion' => '   5.6'],
-            ['id' => '   2', 'name' => '   staging.com', 'phpVersion' => '   None'],
-            ['id' => '   4', 'name' => '   non-archived.com', 'phpVersion' => '   None'],
+        ->expectsTable(['   ID', '   Name', '   PHP', '   Tags'], [
+            ['id' => '   1', 'name' => '   production.com', 'phpVersion' => '   5.6', 'tags' => ''],
+            ['id' => '   2', 'name' => '   staging.com', 'phpVersion' => '   None', 'tags' => ''],
+            ['id' => '   4', 'name' => '   non-archived.com', 'phpVersion' => '   None', 'tags' => ''],
         ], 'compact');
 });


### PR DESCRIPTION
This adds site and server tags to relevant command output.

* `server:current`
* `server:list`
* `server:switch`
* `site:list`

This does rely on a `tags()` method introduced on the [`Site`](https://github.com/laravel/forge-sdk/blob/27af7719beabed3e10f678d66eccb42995037ad6/src/Resources/Site.php#L409-L412) and [`Server`](https://github.com/laravel/forge-sdk/blob/27af7719beabed3e10f678d66eccb42995037ad6/src/Resources/Server.php#L372-L375) resources to handle converting to strings consistently, so tests have been updated to use the relevant resource where appropriate.

Depends on laravel/forge-sdk#126

![Screen Shot 2021-10-01 at 12 12 05 pm](https://user-images.githubusercontent.com/558441/135557425-49cc672a-8681-43dc-ba78-4fe9c8c5afe1.png)

![Screen Shot 2021-10-01 at 12 08 44 pm](https://user-images.githubusercontent.com/558441/135557416-7d95e0e6-9295-4cd3-98a4-3d2496f67bcd.png)

![Screen Shot 2021-10-01 at 12 12 22 pm](https://user-images.githubusercontent.com/558441/135557426-2107abc5-5bcc-4f4b-b346-96d6be4e8eaa.png)

![Screen Shot 2021-10-01 at 12 10 43 pm](https://user-images.githubusercontent.com/558441/135557420-07b45c17-ede1-4efb-b9ae-448e9e586969.png)