### PR TITLE
[1.x] Improves `ssh:configure` command

### DIFF
--- a/app/Commands/SshTestCommand.php
+++ b/app/Commands/SshTestCommand.php
@@ -10,8 +10,7 @@ class SshTestCommand extends Command
      * @var string
      */
     protected $signature = 'ssh:test
-        {server? : The server name}
-        {--key= : The path to the public key}';
+        {server? : The server name}';
 
     /**
      * The description of the command.

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -12,7 +12,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the exception types that are not reported.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $dontReport = [
         ConsoleException::class,

--- a/app/Providers/ForgeServiceProvider.php
+++ b/app/Providers/ForgeServiceProvider.php
@@ -28,7 +28,7 @@ class ForgeServiceProvider extends ServiceProvider
     {
         $this->app->singleton(ForgeRepository::class, function () {
             $config = resolve(ConfigRepository::class);
-            $token = $config->get('token', $_SERVER['FORGE_API_TOKEN'] ?? getenv('FORGE_API_TOKEN') ?? null);
+            $token = $config->get('token', $_SERVER['FORGE_API_TOKEN'] ?? getenv('FORGE_API_TOKEN') ?: null);
 
             $client = new Forge($token);
 

--- a/app/Repositories/ForgeRepository.php
+++ b/app/Repositories/ForgeRepository.php
@@ -81,7 +81,7 @@ class ForgeRepository
      */
     protected function ensureApiToken()
     {
-        $token = $this->config->get('token', $_SERVER['FORGE_API_TOKEN'] ?? getenv('FORGE_API_TOKEN') ?? null);
+        $token = $this->config->get('token', $_SERVER['FORGE_API_TOKEN'] ?? getenv('FORGE_API_TOKEN') ?: null);
 
         abort_if($token == null, 1, 'Please authenticate using the \'login\' command before proceeding.');
 

--- a/app/Repositories/KeyRepository.php
+++ b/app/Repositories/KeyRepository.php
@@ -43,6 +43,8 @@ class KeyRepository
         $keys = json_decode(exec($basePath.'/scripts/keysFactory.php'), true);
 
         File::put($this->keysPath.'/'.$this->privateKeyName($name), $keys['private']);
+        File::chmod($this->keysPath.'/'.$this->privateKeyName($name), 0600);
+
         File::put($this->keysPath.'/'.($localName = $this->publicKeyName($name)), $keys['public']);
 
         return [$localName, $keys['public']];
@@ -119,7 +121,7 @@ class KeyRepository
      */
     protected function privateKeyName($name)
     {
-        return $this->keyName($name).'_rsa';
+        return $this->keyName($name);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel-zero/framework": "^8.9",
         "laravel/forge-sdk": "^3.9",
         "mockery/mockery": "^1.4",
-        "nunomaduro/larastan": "^0.7.10",
+        "nunomaduro/larastan": "^1.0",
         "pestphp/pest": "^1.9",
         "spatie/once": "^2.2"
     },

--- a/scripts/keysFactory.php
+++ b/scripts/keysFactory.php
@@ -1,16 +1,18 @@
 #!/usr/bin/env php
 <?php
 
-use phpseclib3\Crypt\RSA;
+use phpseclib3\Crypt\Common\Formats\Keys\OpenSSH;
+use phpseclib3\Crypt\EC;
 
 require file_exists(__DIR__.'/../vendor/autoload.php') ? __DIR__.'/../vendor/autoload.php' : __DIR__.'/../../../autoload.php';
 
-/** @var \phpseclib3\Crypt\RSA\PrivateKey $private */
-$private = RSA::createKey();
-/** @var \phpseclib3\Crypt\RSA\PrivateKey $public */
-$public = $private->getPublicKey();
+OpenSSH::setComment('forge-cli-generated-key');
+$private = EC::createKey('Ed25519');
+
+$public = $private->getPublicKey()->toString('OpenSSH');
+$private = $private->toString('OpenSSH');
 
 echo json_encode([
-    'private' => (string) $private,
-    'public' => (string) $public,
+    'private' => $private,
+    'public' => $public,
 ]);


### PR DESCRIPTION
This pull request improves the `ssh:configure` command, by changing the algorithm from `RSA` to `ed25519`: https://blog.g3rt.nl/upgrade-your-ssh-keys.html.

In addition, bumps Larastan to its stable version.