### PR TITLE
Improves `ssh:configure` command

### DIFF
--- a/app/Commands/SshConfigureCommand.php
+++ b/app/Commands/SshConfigureCommand.php
@@ -38,7 +38,9 @@ class SshConfigureCommand extends Command
 
         $key = $this->getKey();
 
-        $this->ensureKeyExists($this->getKeyName($key), $key);
+        $privateKey = $this->ensureKeyExists($this->getKeyName($key), $key);
+
+        $this->callSilently('ssh:test', ['--key' => $privateKey]);
 
         $this->successfulStep('SSH key based secure authentication configured successfully');
     }
@@ -48,7 +50,7 @@ class SshConfigureCommand extends Command
      *
      * @param  string  $name
      * @param  string|null  $key
-     * @return void
+     * @return string
      */
     protected function ensureKeyExists($name, $key = null)
     {
@@ -65,6 +67,8 @@ class SshConfigureCommand extends Command
         $this->step('Adding Key <comment>['.$localName.']</comment>'.' With The Name <comment>['.$name.']</comment> To Server <comment>['.$server->name.']</comment>');
 
         $this->forge->createSSHKey($server->id, ['key' => $key, 'name' => $name], true);
+
+        return $this->keys->keysPath().'/'.basename($localName, '.pub');
     }
 
     /**

--- a/app/Commands/SshTestCommand.php
+++ b/app/Commands/SshTestCommand.php
@@ -10,7 +10,8 @@ class SshTestCommand extends Command
      * @var string
      */
     protected $signature = 'ssh:test
-        {server? : The server name}';
+        {server? : The server name}
+        {--key= : The path to the private key}';
 
     /**
      * The description of the command.
@@ -33,6 +34,12 @@ class SshTestCommand extends Command
         }
 
         $this->step('Establishing secure connection');
+
+        if ($this->option('key')) {
+            $this->remote->resolvePrivateKeyUsing(function () {
+                return $this->option('key');
+            });
+        }
 
         $this->remote->ensureSshIsConfigured();
 

--- a/tests/Feature/SshConfigureCommandTest.php
+++ b/tests/Feature/SshConfigureCommandTest.php
@@ -34,6 +34,9 @@ it('can create ssh keys', function () {
         'key' => 'MY KEY Content',
     ], true)->once();
 
+    $this->remote->shouldReceive('resolvePrivateKeyUsing')->once();
+    $this->remote->shouldReceive('ensureSshIsConfigured')->once();
+
     $this->artisan('ssh:configure')
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Server Would You Like To Configure The SSH Key Based Secure Authentication</>', 1)
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Key Would You Like To Use</>', 0)
@@ -76,6 +79,9 @@ it('can reuse ssh keys', function () {
         'name' => 'driesvints',
         'key' => 'MY KEY Content',
     ], true)->once();
+
+    $this->remote->shouldReceive('resolvePrivateKeyUsing')->once();
+    $this->remote->shouldReceive('ensureSshIsConfigured')->once();
 
     $this->artisan('ssh:configure', ['server' => 2])
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Key Would You Like To Use</>', 1)


### PR DESCRIPTION
This pull request improves `ssh:configure` command, by trying a successful SSH connection using the correct private key just after creating the key. By doing this, the next time the `ssh` command is used, the command will know the correct private key that should be used.

Fixes #45