### PR TITLE
[1.x] Migrates to Laravel Zero 9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [8.0, 8.1]
 
     name: PHP ${{ matrix.php }}
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Execute static analysis
         run: vendor/bin/phpstan
-        if: matrix.php == '8.0'
+        if: matrix.php == '8.1'
 
       - name: Execute unit/feature tests
         run: vendor/bin/pest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [Unreleased](https://github.com/laravel/forge-cli/compare/v1.3.4...master)
 
 ### Fixed
-- PHP 8.1 deprecation warnings ([]())
+- PHP 8.1 deprecation warnings ([#54](https://github.com/laravel/forge-cli/pull/54))
 
 ### Removed
-- PHP 7.3 and PHP 7.4 support ([]())
+- PHP 7.3 and PHP 7.4 support ([#54](https://github.com/laravel/forge-cli/pull/54))
 
 ## [v1.3.4 (2021-11-16)](https://github.com/laravel/forge-cli/compare/v1.3.3...v1.3.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/laravel/forge-cli/compare/v1.3.4...master)
 
+### Fixed
+- PHP 8.1 deprecation warnings ([]())
+
+### Removed
+- PHP 7.3 and PHP 7.4 support ([]())
 
 ## [v1.3.4 (2021-11-16)](https://github.com/laravel/forge-cli/compare/v1.3.3...v1.3.4)
 

--- a/app/Commands/ServerSwitchCommand.php
+++ b/app/Commands/ServerSwitchCommand.php
@@ -42,7 +42,7 @@ class ServerSwitchCommand extends Command
 
         $this->config->set('server', $server->id);
 
-        Once\Cache::flush();
+        Once\Cache::getInstance()->flush();
 
         $this->successfulStep(
             'Current server context changed successfully to <comment>['.$server->name.']</comment>'

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "phpseclib/phpseclib": "^3.0"
     },
     "require-dev": {
-        "laravel-zero/framework": "^8.9",
-        "laravel/forge-sdk": "^3.9",
-        "mockery/mockery": "^1.4",
-        "nunomaduro/larastan": "^1.0",
-        "pestphp/pest": "^1.9",
-        "spatie/once": "^2.2"
+        "laravel-zero/framework": "^9.0",
+        "laravel/forge-sdk": "^3.12",
+        "mockery/mockery": "^1.5",
+        "nunomaduro/larastan": "^2.0",
+        "pestphp/pest": "^1.21",
+        "spatie/once": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,7 +38,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "7.3"
+            "php": "8.0.2"
         },
         "allow-plugins": {
             "pestphp/pest-plugin": true

--- a/config/commands.php
+++ b/config/commands.php
@@ -58,8 +58,6 @@ return [
         // Illuminate...
         Illuminate\Console\Scheduling\ScheduleRunCommand::class,
         Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
-        Illuminate\Foundation\Console\VendorPublishCommand::class,
-        Illuminate\Foundation\Console\VendorPublishCommand::class,
 
         // Laravel Zero...
         LaravelZero\Framework\Commands\BuildCommand::class,
@@ -93,7 +91,8 @@ return [
     */
 
     'remove' => [
-        // ..
+        Illuminate\Foundation\Console\VendorPublishCommand::class,
+        Symfony\Component\Console\Command\DumpCompletionCommand::class,
     ],
 
 ];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,8 @@ parameters:
     - bootstrap
     - config
     - scripts
-  level: 6
+  level: 5
   ignoreErrors:
     - '#Unsafe usage of new static\(\)#'
   checkMissingIterableValueType: false
+  checkGenericClassInNonGenericObjectType: false

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -25,7 +25,7 @@ use Tests\CreatesApplication;
 
 uses(TestCase::class, CreatesApplication::class)
     ->beforeEach(function () {
-        Once\Cache::flush();
+        Once\Cache::getInstance()->flush();
 
         (new Filesystem)->deleteDirectory(base_path('tests/.laravel-forge'));
 


### PR DESCRIPTION
This pull request migrates Forge CLI to Laravel Zero 9, and in the process:

- Fixes PHP 8.1  deprecation warnings on when using the CLI tool from a build file.
- Drops PHP 7.3, and PHP 7.4.

Note, that, once this pull request gets merged, we don't need a major version. Existing customers, using PHP 7.3 / PHP 7.4, will continue to use the existing version, while existing customers, using PHP 8.0 / PHP 8.1 will get the new one.