### PR TITLE
[1.x] Support per-project configuration files

### DIFF
--- a/app/Commands/InitCommand.php
+++ b/app/Commands/InitCommand.php
@@ -2,6 +2,8 @@
 
 namespace App\Commands;
 
+use Illuminate\Support\Facades\File;
+
 class InitCommand extends Command
 {
     /**
@@ -27,17 +29,17 @@ class InitCommand extends Command
     {
         $path = getcwd() . '/.laravel-forge';
 
-        if (! is_dir($path)) {
-            mkdir($path);
+        if (! File::isDirectory($path)) {
+            File::makeDirectory($path);
         }
 
         $gitignore = getcwd() . '/.gitignore';
 
-        if (is_writeable($gitignore)) {
-            $this->updateGitignore($gitignore);
+        if (File::isWritable($gitignore)) {
+            File::append($gitignore, '.laravel-forge' . PHP_EOL);
         }
 
-        $this->successfulStep("Initialized Successfully.");
+        $this->successfulStep("Initialized Successfully");
     }
 
     /**
@@ -48,9 +50,6 @@ class InitCommand extends Command
      */
     protected function updateGitignore(string $path)
     {
-        $contents = file_get_contents($path);
-        $contents .= '.laravel-forge' . PHP_EOL;
 
-        file_put_contents($path, $contents);
     }
 }

--- a/app/Commands/InitCommand.php
+++ b/app/Commands/InitCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Commands;
+
+class InitCommand extends Command
+{
+    /**
+     * The signature of the command.
+     *
+     * @var string
+     */
+    protected $signature = 'init';
+
+    /**
+     * The description of the command.
+     *
+     * @var string
+     */
+    protected $description = 'Initialise the Forge CLI in the current directory.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $path = getcwd() . '/.laravel-forge';
+
+        if (! is_dir($path)) {
+            mkdir($path);
+        }
+
+        $gitignore = getcwd() . '/.gitignore';
+
+        if (is_writeable($gitignore)) {
+            $this->updateGitignore($gitignore);
+        }
+
+        $this->successfulStep("Initialized Successfully.");
+    }
+
+    /**
+     * Update the project's .gitignore file.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    protected function updateGitignore(string $path)
+    {
+        $contents = file_get_contents($path);
+        $contents .= '.laravel-forge' . PHP_EOL;
+
+        file_put_contents($path, $contents);
+    }
+}

--- a/app/Providers/ConfigServiceProvider.php
+++ b/app/Providers/ConfigServiceProvider.php
@@ -25,9 +25,13 @@ class ConfigServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(ConfigRepository::class, function () {
-            $path = isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] == 'testing'
-                 ? base_path('tests')
-                 : ($_SERVER['HOME'] ?? $_SERVER['USERPROFILE']);
+            if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] == 'testing') {
+                $path = base_path('tests');
+            } elseif (is_dir(getcwd() . '/.laravel-forge')) {
+                $path = getcwd();
+            } else {
+                $path = ($_SERVER['HOME'] ?? $_SERVER['USERPROFILE']);
+            }
 
             $path .= '/.laravel-forge/config.json';
 

--- a/tests/Feature/InitCommandTest.php
+++ b/tests/Feature/InitCommandTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+
+it('can initialize inside of a directory', function () {
+    File::shouldReceive('isDirectory')
+        ->once()
+        ->andReturnFalse();
+
+    File::shouldReceive('makeDirectory')
+        ->once()
+        ->with(getcwd() . '/.laravel-forge')
+        ->andReturnTrue();
+
+    File::shouldReceive('isWritable')
+        ->once()
+        ->andReturnTrue();
+
+    File::shouldReceive('append')
+        ->once()
+        ->with(getcwd() . '/.gitignore', '.laravel-forge' . PHP_EOL)
+        ->andReturn(15);
+
+    $this->artisan('init')
+        ->expectsOutput('==> Initialized Successfully');
+});


### PR DESCRIPTION
This pull request will allow users to store their Forge config on a per-project basis. It works by updating the `ConfigRepository` binding to check if a `.laravel-forge` folder exists in the current working directory.

For example, in a Laravel application you would create this folder and then login to Forge. Your API tokens and other configuration values would be stored in `my-project/.laravel-forge` instead of the home directory / global config location.

This effectively allows you to use the Forge CLI with multiple Forge accounts, useful if you have clients with their own accounts or a personal and work account (both of which apply to me).

My original idea was to support a `forge.json` in the root of the project instead, but the use of a "hidden" folder makes more sense as it'll be gitignored like other dot-folders in projects.