### PR TITLE
Fix for documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In addition, Forge can assist you in managing scheduled jobs, queue workers, SSL
 
 ## Official Documentation
 
-Documentation for Forge CLI can be found on the [Laravel Forge website](https://forge.laravel.com/docs/1.0/accounts/cli.html).
+Documentation for Forge CLI can be found on the [Laravel Forge website](https://forge.laravel.com/docs/1.0/cli.html).
 
 ## Contributing
 


### PR DESCRIPTION
Hello,

First of all, thank you so much for all these incredible products!

There is a small issue with the documentation URL that I noticed. The existent url is causing a 404 error, so I pointed it to the next cli page.

The current page mentioned in the readme:

![Screenshot from 2022-06-06 11-06-00](https://user-images.githubusercontent.com/1092909/172210978-188d74c6-fd0a-46c8-9dc2-b24447a7d442.png)


Cheers,
Savio