### PR TITLE
Add option for specifying remote user when calling the ssh command

### DIFF
--- a/app/Commands/SshCommand.php
+++ b/app/Commands/SshCommand.php
@@ -34,6 +34,7 @@ class SshCommand extends Command
         }
 
         $server = $this->currentServer();
+
         $username = $this->option('user') ?: 'forge';
 
         $this->step('Establishing secure connection');

--- a/app/Commands/SshCommand.php
+++ b/app/Commands/SshCommand.php
@@ -9,7 +9,7 @@ class SshCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'ssh {server? : The server name} {--u|user= : Remote username}';
+    protected $signature = 'ssh {server? : The server name} {--u|user= : The remote username}';
 
     /**
      * The description of the command.
@@ -34,7 +34,7 @@ class SshCommand extends Command
         }
 
         $server = $this->currentServer();
-        $username = $this->option('user') ?? 'forge';
+        $username = $this->option('user') ?: 'forge';
 
         $this->step('Establishing secure connection');
 
@@ -42,9 +42,7 @@ class SshCommand extends Command
 
         $this->successfulStep('Connected To <comment>['.$server->name.']</comment>');
 
-        $exitCode = $this->remote->passthru(
-            user: $username
-        );
+        $exitCode = $this->remote->passthru(null, $username);
 
         abort_if($exitCode == 255, $exitCode, 'Unable to connect to remote server. Have you configured an SSH key?');
 

--- a/app/Commands/SshCommand.php
+++ b/app/Commands/SshCommand.php
@@ -9,7 +9,7 @@ class SshCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'ssh {server? : The server name}';
+    protected $signature = 'ssh {server? : The server name} {--u|user= : Remote username}';
 
     /**
      * The description of the command.
@@ -34,6 +34,7 @@ class SshCommand extends Command
         }
 
         $server = $this->currentServer();
+        $username = $this->option('user') ?? 'forge';
 
         $this->step('Establishing secure connection');
 
@@ -41,7 +42,9 @@ class SshCommand extends Command
 
         $this->successfulStep('Connected To <comment>['.$server->name.']</comment>');
 
-        $exitCode = $this->remote->passthru();
+        $exitCode = $this->remote->passthru(
+            user: $username
+        );
 
         abort_if($exitCode == 255, $exitCode, 'Unable to connect to remote server. Have you configured an SSH key?');
 

--- a/app/Commands/SshCommand.php
+++ b/app/Commands/SshCommand.php
@@ -9,7 +9,7 @@ class SshCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'ssh {server? : The server name} {--u|user= : The remote username}';
+    protected $signature = 'ssh {server? : The server name} {--u|user= : The user to connect to the server as}';
 
     /**
      * The description of the command.

--- a/app/Repositories/RemoteRepository.php
+++ b/app/Repositories/RemoteRepository.php
@@ -57,7 +57,7 @@ class RemoteRepository
      * Execute a command against the shell, and displays the output.
      *
      * @param  string|null  $command
-     * @param  string       $user
+     * @param  string  $user
      * @return int
      */
     public function passthru($command = null, $user = 'forge')
@@ -199,7 +199,7 @@ class RemoteRepository
      * Returns the "ssh" shell command to be run.
      *
      * @param  string|null  $command
-     * @param  string       $user
+     * @param  string  $user
      * @return string
      */
     protected function ssh($command = null, $user = 'forge')

--- a/app/Repositories/RemoteRepository.php
+++ b/app/Repositories/RemoteRepository.php
@@ -57,13 +57,14 @@ class RemoteRepository
      * Execute a command against the shell, and displays the output.
      *
      * @param  string|null  $command
+     * @param  string       $user
      * @return int
      */
-    public function passthru($command = null)
+    public function passthru($command = null, $user = 'forge')
     {
         $this->ensureSshIsConfigured();
 
-        passthru($this->ssh('"'.$command.'"'), $exitCode);
+        passthru($this->ssh('"'.$command.'"', $user), $exitCode);
 
         return (int) $exitCode;
     }
@@ -195,12 +196,13 @@ class RemoteRepository
     }
 
     /**
-     * Returns the "ssh" sheel command to be run.
+     * Returns the "ssh" shell command to be run.
      *
-     * @param  string  $command|null
+     * @param  string|null  $command
+     * @param  string       $user
      * @return string
      */
-    protected function ssh($command = null)
+    protected function ssh($command = null, $user = 'forge')
     {
         $options = collect([
             'ConnectTimeout' => 5,
@@ -221,8 +223,9 @@ class RemoteRepository
         }
 
         return trim(sprintf(
-            'ssh %s -t forge@%s %s',
+            'ssh %s -t %s@%s %s',
             $options,
+            $user,
             $this->server->ipAddress,
             $command,
         ));

--- a/app/Support/Panic.php
+++ b/app/Support/Panic.php
@@ -27,6 +27,6 @@ class Panic
             - Operating System: %s
             - Error Message: %s.
             EOF
-        , config('app.version'), phpversion(), PHP_OS, $message));
+            , config('app.version'), phpversion(), PHP_OS, $message));
     }
 }

--- a/tests/Feature/SshCommandTest.php
+++ b/tests/Feature/SshCommandTest.php
@@ -18,7 +18,7 @@ it('can create ssh connections', function () {
     $this->artisan('ssh')->assertExitCode(0);
 });
 
-it('can connect to a specific ssh user', function() {
+it('can connect to a specific ssh user', function () {
     $this->config->set('server', 1);
 
     $this->forge->shouldReceive('server')
@@ -36,11 +36,11 @@ it('can connect to a specific ssh user', function() {
         ->andReturn(0);
 
     $this->artisan('ssh', [
-        '--user' => 'testuser'
+        '--user' => 'testuser',
     ])->assertExitCode(0);
 });
 
-it('defaults to the forge user', function() {
+it('defaults to the forge user', function () {
     $this->config->set('server', 1);
 
     $this->forge->shouldReceive('server')

--- a/tests/Feature/SshCommandTest.php
+++ b/tests/Feature/SshCommandTest.php
@@ -18,6 +18,48 @@ it('can create ssh connections', function () {
     $this->artisan('ssh')->assertExitCode(0);
 });
 
+it('can connect to a specific ssh user', function() {
+    $this->config->set('server', 1);
+
+    $this->forge->shouldReceive('server')
+        ->once()
+        ->with(1)
+        ->andReturn((object) [
+            'name' => 'production',
+            'ipAddress' => '123.456.789.000',
+        ]);
+
+    $this->remote->shouldReceive('ensureSshIsConfigured');
+
+    $this->remote->shouldReceive('passthru')
+        ->with(null, 'testuser')
+        ->andReturn(0);
+
+    $this->artisan('ssh', [
+        '--user' => 'testuser'
+    ])->assertExitCode(0);
+});
+
+it('defaults to the forge user', function() {
+    $this->config->set('server', 1);
+
+    $this->forge->shouldReceive('server')
+        ->once()
+        ->with(1)
+        ->andReturn((object) [
+            'name' => 'production',
+            'ipAddress' => '123.456.789.000',
+        ]);
+
+    $this->remote->shouldReceive('ensureSshIsConfigured');
+
+    $this->remote->shouldReceive('passthru')
+        ->with(null, 'forge')
+        ->andReturn(0);
+
+    $this->artisan('ssh')->assertExitCode(0);
+});
+
 it('can not create ssh connections when ssh key is missing', function () {
     $this->config->set('server', 1);
 

--- a/tests/Unit/Repositories/RemoteRepositoryTest.php
+++ b/tests/Unit/Repositories/RemoteRepositoryTest.php
@@ -64,7 +64,7 @@ class LocalRepository extends RemoteRepository
         $this->sanitizableOutput = $sanitizableOutput;
     }
 
-    protected function ssh($command = null)
+    protected function ssh($command = null, $user = null)
     {
         return $command;
     }


### PR DESCRIPTION
When working with site isolation, it is sometimes useful to be able to directly connect to a remote user, without the need to call `su`. 

This commit adds an additional option to the `forge ssh` command called `--user`, which accepts the name of the remote user for which the connection is attempted.

The option defaults to to `forge` which was the previous fixed user.