### PR TITLE
Add prompt/option for username parameter required by forge api

### DIFF
--- a/app/Commands/SshConfigureCommand.php
+++ b/app/Commands/SshConfigureCommand.php
@@ -115,7 +115,7 @@ class SshConfigureCommand extends Command
     }
 
     /**
-     * Prompt for a "server user"
+     * Prompt for a "server user".
      *
      * @return string
      */

--- a/tests/Feature/SshConfigureCommandTest.php
+++ b/tests/Feature/SshConfigureCommandTest.php
@@ -32,6 +32,7 @@ it('can create ssh keys', function () {
     $this->forge->shouldReceive('createSSHKey')->with(1, [
         'name' => 'driesvints',
         'key' => 'MY KEY Content',
+        'username' => 'morales2k'
     ], true)->once();
 
     $this->remote->shouldReceive('resolvePrivateKeyUsing')->once();
@@ -41,6 +42,7 @@ it('can create ssh keys', function () {
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Server Would You Like To Configure The SSH Key Based Secure Authentication</>', 1)
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Key Would You Like To Use</>', 0)
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>What Should The SSH Key Be Named</>', 'driesvints')
+        ->expectsQuestion('<fg=yellow>‣</> <options=bold>What Username Should We Use For The Selected Server</>', 'morales2k')
         ->expectsOutput('==> Creating Key [driesvints_rsa.pub]')
         ->expectsOutput('==> Adding Key [driesvints_rsa.pub] With The Name [driesvints] To Server [production]')
         ->expectsOutput('==> SSH Key Based Secure Authentication Configured Successfully');
@@ -78,6 +80,7 @@ it('can reuse ssh keys', function () {
     $this->forge->shouldReceive('createSSHKey')->with(2, [
         'name' => 'driesvints',
         'key' => 'MY KEY Content',
+        'username' => 'morales2k'
     ], true)->once();
 
     $this->remote->shouldReceive('resolvePrivateKeyUsing')->once();
@@ -86,6 +89,7 @@ it('can reuse ssh keys', function () {
     $this->artisan('ssh:configure', ['server' => 2])
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Key Would You Like To Use</>', 1)
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>What Should The SSH Key Be Named In Forge</>', 'driesvints')
+        ->expectsQuestion('<fg=yellow>‣</> <options=bold>What Username Should We Use For The Selected Server</>', 'morales2k')
         ->expectsOutput('==> Adding Key [id_rsa.pub] With The Name [driesvints] To Server [production]')
         ->expectsOutput('==> SSH Key Based Secure Authentication Configured Successfully');
 });

--- a/tests/Feature/SshConfigureCommandTest.php
+++ b/tests/Feature/SshConfigureCommandTest.php
@@ -32,7 +32,7 @@ it('can create ssh keys', function () {
     $this->forge->shouldReceive('createSSHKey')->with(1, [
         'name' => 'driesvints',
         'key' => 'MY KEY Content',
-        'username' => 'morales2k'
+        'username' => 'morales2k',
     ], true)->once();
 
     $this->remote->shouldReceive('resolvePrivateKeyUsing')->once();
@@ -80,7 +80,7 @@ it('can reuse ssh keys', function () {
     $this->forge->shouldReceive('createSSHKey')->with(2, [
         'name' => 'driesvints',
         'key' => 'MY KEY Content',
-        'username' => 'morales2k'
+        'username' => 'morales2k',
     ], true)->once();
 
     $this->remote->shouldReceive('resolvePrivateKeyUsing')->once();


### PR DESCRIPTION
Prior to this, adding new key using ssh:configure command would always end in error when trying to add the key because it was missing the 'username' parameter.

This adds a way to pass the user as an option when calling ssh:configure, or it will prompt for a username offering 'forge' as default username.

