### PR TITLE
[1.x] Migrates to Laravel Zero 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo
           ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,11 @@ on:
 
 jobs:
   tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, windows-2019]
         php: [8.1, 8.2]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,15 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2]
+        os: [ubuntu-22.04, windows-2019]
+        php: [8.1, 8.2]
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         php: [8.1, 8.2]
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.os }}
+    name: PHP ${{ matrix.php }}
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "phpseclib/phpseclib": "^3.0"
+        "php": "^8.1.0",
+        "phpseclib/phpseclib": "^3.0.18"
     },
     "require-dev": {
-        "laravel-zero/framework": "^9.0",
-        "laravel/forge-sdk": "^3.12",
-        "mockery/mockery": "^1.5",
-        "nunomaduro/larastan": "^2.0",
-        "pestphp/pest": "^1.21",
-        "spatie/once": "^3.0"
+        "laravel-zero/framework": "^10.0.0",
+        "laravel/forge-sdk": "^3.13.3",
+        "mockery/mockery": "^1.5.1",
+        "nunomaduro/larastan": "^2.4.0",
+        "pestphp/pest": "^1.22.4",
+        "spatie/once": "^3.1.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,7 +38,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.0.2"
+            "php": "8.1.0"
         },
         "allow-plugins": {
             "pestphp/pest-plugin": true


### PR DESCRIPTION
This pull request accomplishes three tasks:

- Upgrades Pint 1 to Laravel Zero 10.
- Removes support for PHP 8.0, **limiting Forge CLI (up to) to version 1.6.0** for environments using PHP 8.0, as Pint 1.6.0 will not support PHP 8.0.
- Resolves an internal issue preventing us from building the Pint binary with PHP 8.2.