### PR TITLE
Applied patched version of `phpseclib/phpseclib`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "phpseclib/phpseclib": "^3.0.18"
+        "phpseclib/phpseclib": "^3.0.19"
     },
     "require-dev": {
         "laravel-zero/framework": "^10.0.0",


### PR DESCRIPTION
Current version of `phpseclib/phpseclib` (3.0.18) has a [security vulnerability](https://github.com/advisories/GHSA-hm7p-r324-hhf3) which is patched in 3.0.19.