### PR TITLE
Support PHP 8.2 and use single source of truth

### DIFF
--- a/app/Commands/PhpLogsCommand.php
+++ b/app/Commands/PhpLogsCommand.php
@@ -33,7 +33,7 @@ class PhpLogsCommand extends Command
         $this->ensurePhpExists();
 
         $version = $this->argument('version');
-        $versions = ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1'];
+        $versions = PhpVersion::VERSIONS;
 
         abort_if(
             ! is_null($version) && ! in_array($version, $versions),

--- a/app/Commands/PhpRestartCommand.php
+++ b/app/Commands/PhpRestartCommand.php
@@ -34,7 +34,7 @@ class PhpRestartCommand extends Command
         $server = $this->currentServer();
 
         $version = $this->argument('version');
-        $versions = ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1'];
+        $versions = PhpVersion::VERSIONS;
 
         if (! is_null($version) && ! in_array($version, $versions)) {
             abort(1, 'PHP version needs to be one of these values: '.implode(', ', $versions).'.');

--- a/app/Commands/PhpStatusCommand.php
+++ b/app/Commands/PhpStatusCommand.php
@@ -34,7 +34,7 @@ class PhpStatusCommand extends Command
         $server = $this->currentServer();
 
         $version = $this->argument('version');
-        $versions = ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1'];
+        $versions = PhpVersion::VERSIONS;
 
         if (! is_null($version) && ! in_array($version, $versions)) {
             abort(1, 'PHP version needs to be one of these values: '.implode(', ', $versions).'.');

--- a/app/Support/PhpVersion.php
+++ b/app/Support/PhpVersion.php
@@ -7,7 +7,7 @@ class PhpVersion
     /**
      * The available PHP versions.
      *
-     * @var array
+     * @var array<int, string>
      */
     const VERSIONS = ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2'];
 

--- a/app/Support/PhpVersion.php
+++ b/app/Support/PhpVersion.php
@@ -5,6 +5,13 @@ namespace App\Support;
 class PhpVersion
 {
     /**
+     * The available PHP versions.
+     *
+     * @var array
+     */
+    const VERSIONS = ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2'];
+
+    /**
      * The PHP version.
      *
      * @var string


### PR DESCRIPTION
- Add support for PHP 8.2
- Use a single source of truth of available PHP versions.