### PR TITLE
fix: Use custom ssh port in CLI commands if defined

### DIFF
--- a/app/Repositories/RemoteRepository.php
+++ b/app/Repositories/RemoteRepository.php
@@ -223,8 +223,9 @@ class RemoteRepository
         }
 
         return trim(sprintf(
-            'ssh %s -t %s@%s %s',
+            'ssh %s -p %s -t %s@%s %s',
             $options,
+            $this->server->sshPort ?? 22,
             $user,
             $this->server->ipAddress,
             $command,


### PR DESCRIPTION
Currently the ssh port on a server is not passed into the ssh command generated, making people unable to use the CLI if they use a custom ssh port.