### PR TITLE
fix: deployment command showing wrong output

### DIFF
--- a/app/Commands/Concerns/InteractsWithEvents.php
+++ b/app/Commands/Concerns/InteractsWithEvents.php
@@ -45,19 +45,30 @@ trait InteractsWithEvents
             }
 
             if ($exitCode == 0) {
-                collect($output)->slice(count($this->outputBuffer[$eventId]))
-                    ->map('trim')
-                    ->filter(function ($line) {
-                        return ! empty($line);
-                    })->each(function ($line) {
-                        $this->line("  <fg=#6C7280>▕</> $line");
-                    });
+                $this->displayOutput(collect($output)->slice(count($this->outputBuffer[$eventId]))
+                    ->map('trim'));
 
                 $this->outputBuffer[$eventId] = $output;
             }
         } while ($while && call_user_func($while));
 
         $while ? $this->displayEventOutput($username, $eventId) : $this->line('');
+    }
+
+    /**
+     * Display the output of the given collection indenting each line.
+     *
+     * @param  \Illuminate\Support\Collection  $collection
+     * @return void
+     */
+    protected function displayOutput($collection)
+    {
+        $collection->map('trim')
+            ->filter(function ($line) {
+                return ! empty($line);
+            })->each(function ($line) {
+                return $this->line("  <fg=#6C7280>▕</> $line");
+            });
     }
 
     /**

--- a/app/Commands/DeployCommand.php
+++ b/app/Commands/DeployCommand.php
@@ -54,7 +54,7 @@ class DeployCommand extends Command
 
         $deploymentId = $this->ensureDeploymentHaveStarted($site);
 
-        $deployment = $this->ensureDeploymentHaveFinished($server, $site, $deploymentId);
+        $deployment = $this->ensureDeploymentHasFinished($server, $site, $deploymentId);
 
         $output = $this->forge->siteDeploymentOutput($server->id, $site->id, $deploymentId);
         $output = explode(PHP_EOL, $output);
@@ -95,14 +95,14 @@ class DeployCommand extends Command
     }
 
     /**
-     * Ensure the deployment have finished on the server.
+     * Ensure the deployment has finished on the server.
      *
      * @param  \Laravel\Forge\Resources\Server  $server
      * @param  \Laravel\Forge\Resources\Site  $site
-     * @param  \Laravel\Forge\Resources\Site  $site
+     * @param  int  $deploymentId
      * @return object
      */
-    protected function ensureDeploymentHaveFinished($server, $site, $deploymentId)
+    protected function ensureDeploymentHasFinished($server, $site, $deploymentId)
     {
         do {
             $this->time->sleep(1);


### PR DESCRIPTION
Deployment command was looking for an event id by the description, however deployment commands always have the same description. This resulted in it getting the previous deployment output.

Changed to use deployment id for finding deployment output instead of event id.