### PR TITLE
Set a User-Agent string

### DIFF
--- a/app/Repositories/ForgeRepository.php
+++ b/app/Repositories/ForgeRepository.php
@@ -93,6 +93,7 @@ class ForgeRepository
                     'Authorization' => 'Bearer '.$token,
                     'Accept' => 'application/json',
                     'Content-Type' => 'application/json',
+                    'User-Agent' => 'Laravel Forge CLI/v'.config('app.version'),
                 ],
             ]) : null;
 


### PR DESCRIPTION
Setting a User-Agent string allows us to identify requests made by the CLI tool.