### PR TITLE
Fix critical bugs: missing DB types, null references, path logic, signature typo

### DIFF
--- a/app/Commands/CommandCommand.php
+++ b/app/Commands/CommandCommand.php
@@ -46,8 +46,10 @@ class CommandCommand extends Command
         do {
             $this->time->sleep(1);
 
-            /** @var \Laravel\Forge\Resources\SiteCommand $command */
+            /** @var \Laravel\Forge\Resources\SiteCommand|null $command */
             $command = collect($this->forge->getSiteCommand($server->id, $siteId, $command->id))->first();
+
+            abort_if(is_null($command), 1, 'The command could not be found.');
         } while ($command->status == 'waiting');
 
         $this->step('Running');
@@ -57,9 +59,11 @@ class CommandCommand extends Command
         $username = $this->forge->site($server->id, $siteId)->username;
 
         $this->displayEventOutput($username, $eventId, function () use ($server, $siteId, &$command) {
+            /** @var \Laravel\Forge\Resources\SiteCommand|null $command */
             $command = collect($this->forge->getSiteCommand($server->id, $siteId, $command->id))->first();
 
-            /** @var \Laravel\Forge\Resources\SiteCommand $command */
+            abort_if(is_null($command), 1, 'The command could not be found.');
+
             return $command->status == 'running';
         });
 

--- a/app/Commands/Concerns/InteractsWithLogs.php
+++ b/app/Commands/Concerns/InteractsWithLogs.php
@@ -50,7 +50,7 @@ trait InteractsWithLogs
         $sitePath = '/home/'.$site->username.'/'.$site->name;
 
         $sitePath = basename($sitePath) == 'current'
-            ? basename($sitePath)
+            ? dirname($sitePath)
             : $sitePath;
 
         $this->showRemoteLogs(collect($files)->map(function ($file) use ($sitePath) {

--- a/app/Commands/DaemonLogsCommand.php
+++ b/app/Commands/DaemonLogsCommand.php
@@ -12,7 +12,7 @@ class DaemonLogsCommand extends Command
      * @var string
      */
     protected $signature = 'daemon:logs {daemon? : The daemon ID}
-    `                                   {--f|follow : Monitor the log changes in realtime}';
+                                        {--f|follow : Monitor the log changes in realtime}';
 
     /**
      * The description of the command.

--- a/app/Commands/DatabaseLogsCommand.php
+++ b/app/Commands/DatabaseLogsCommand.php
@@ -32,7 +32,7 @@ class DatabaseLogsCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $this->currentServer()->databaseType;
 
-        if (! in_array($databaseType, ['mysql', 'mysql8', 'postgres'])) {
+        if (! in_array($databaseType, ['mysql', 'mysql8', 'mariadb', 'postgres', 'postgres13'])) {
             abort(1, 'Retrieving logs from ['.$databaseType.'] databases is not supported.');
         }
 

--- a/app/Commands/DeployLogsCommand.php
+++ b/app/Commands/DeployLogsCommand.php
@@ -31,10 +31,12 @@ class DeployLogsCommand extends Command
 
         $this->step('Retrieving the latest deployment logs');
 
-        $lastDeploymentId = optional(collect($this->forge->siteDeployments(
+        $lastDeployment = collect($this->forge->siteDeployments(
             $this->currentServer()->id,
             $siteId,
-        ))->first())['id'];
+        ))->first();
+
+        $lastDeploymentId = $lastDeployment ? $lastDeployment['id'] : null;
 
         abort_if(is_null($lastDeploymentId), 1, 'This site has not been deployed.');
 


### PR DESCRIPTION
Fixes #117, #118, #119, #120, #121

## Summary

- **Missing DB types** (#117): `DatabaseLogsCommand` missing `mariadb` and `postgres13` support (all other DB commands have them)
- **Null crash** (#118): `CommandCommand` crashes when API returns empty response — added null check after `collect()->first()`
- **Broken optional()** (#119): `DeployLogsCommand` uses `optional(...)['id']` which fails on null — extracted to separate null check
- **Wrong path function** (#120): `InteractsWithLogs` returns `basename()` instead of `dirname()` for current symlink paths, breaking log resolution
- **Signature typo** (#121): Stray backtick in `DaemonLogsCommand` signature string

## Test plan

- [ ] Verify `database:logs` works for MariaDB and PostgreSQL 13 servers
- [ ] Verify `command` handles empty API response gracefully
- [ ] Verify `deploy:logs` works when no deployments exist
- [ ] Verify site logs work correctly for sites using current/release symlink structure
- [ ] Verify `daemon:logs` command signature parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)