### PR TITLE
Fix typo, password exposure, version check error handling, and UX improvements

### DIFF
--- a/app/Commands/Concerns/InteractsWithVersions.php
+++ b/app/Commands/Concerns/InteractsWithVersions.php
@@ -33,12 +33,28 @@ trait InteractsWithVersions
     protected function getLatestVersion()
     {
         $resolver = static::$latestVersionResolver ?? function () {
-            $package = json_decode(file_get_contents(
-                'https://packagist.org/p2/laravel/forge-cli.json'
-            ), true);
+            try {
+                $context = stream_context_create([
+                    'http' => ['timeout' => 5],
+                ]);
 
-            return collect($package['packages']['laravel/forge-cli'])
-                ->first()['version'];
+                $response = file_get_contents(
+                    'https://packagist.org/p2/laravel/forge-cli.json',
+                    false,
+                    $context
+                );
+
+                if ($response === false) {
+                    return 'v'.config('app.version');
+                }
+
+                $package = json_decode($response, true);
+
+                return collect($package['packages']['laravel/forge-cli'])
+                    ->first()['version'];
+            } catch (\Throwable $e) {
+                return 'v'.config('app.version');
+            }
         };
 
         if (is_null($this->config->get('latest_version_verified_at'))) {

--- a/app/Commands/DaemonLogsCommand.php
+++ b/app/Commands/DaemonLogsCommand.php
@@ -28,7 +28,7 @@ class DaemonLogsCommand extends Command
      */
     public function handle()
     {
-        $daemonId = $this->askForDaemon('Which daemon would you like to retrieve the logs from');
+        $daemonId = $this->argument('daemon') ?? $this->askForDaemon('Which daemon would you like to retrieve the logs from');
 
         $daemon = $this->forge->daemon($this->currentServer()->id, $daemonId);
 

--- a/app/Commands/DaemonRestartCommand.php
+++ b/app/Commands/DaemonRestartCommand.php
@@ -27,11 +27,11 @@ class DaemonRestartCommand extends Command
     {
         $server = $this->currentServer();
 
-        $daemonId = $this->askForDaemon('Which daemon would you like to restart');
+        $daemonId = $this->argument('daemon') ?? $this->askForDaemon('Which daemon would you like to restart');
 
         $daemon = $this->forge->daemon($server->id, $daemonId);
 
-        abort_unless($daemon->status == 'installed', 1, 'This deamon is not installed or is not running.');
+        abort_unless($daemon->status == 'installed', 1, 'This daemon is not installed or is not running.');
 
         $this->step(['Restarting Daemon %s', $daemon->command]);
 

--- a/app/Commands/DatabaseShellCommand.php
+++ b/app/Commands/DatabaseShellCommand.php
@@ -72,7 +72,7 @@ class DatabaseShellCommand extends Command
     public function connectToMysql($serverId, $user, $password, $database)
     {
         return $this->remote->passthru(sprintf(
-            'mysql -u %s -p%s %s', $user, $password, $database
+            'MYSQL_PWD=%s mysql -u %s %s', $password, $user, $database
         ));
     }
 

--- a/app/Commands/LogoutCommand.php
+++ b/app/Commands/LogoutCommand.php
@@ -25,6 +25,10 @@ class LogoutCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmStep('Are you sure you want to log out? This will remove your stored API token and configuration')) {
+            return;
+        }
+
         $this->config->flush();
 
         $this->successfulStep('Logged Out Successfully');


### PR DESCRIPTION
Fixes #112, #113, #114, #115, #116

> **Note:** This PR bundles multiple independent fixes. Consider splitting into separate PRs per issue for easier review.

## Summary

### Security
- **Password exposure** (#112): `DatabaseShellCommand` passes password via `-p` CLI argument, visible in `ps aux`. Changed to `MYSQL_PWD` environment variable.

### Bug fixes
- **CLI hang** (#113): `InteractsWithVersions` calls Packagist with no timeout or error handling. Added 5s timeout, try-catch fallback to current version.
- **"deamon" typo** (#114): Fixed typo in `DaemonRestartCommand` error message.
- **Daemon argument ignored** (#115): `DaemonLogsCommand` and `DaemonRestartCommand` define a `{daemon}` argument but always prompt interactively. Now checks argument first.

### UX
- **Logout confirmation** (#116): `LogoutCommand` flushes all config without confirmation. Added confirmation prompt.

## Test plan

- [ ] Verify `database:shell` connects without exposing password in `ps aux`
- [ ] Verify CLI works normally when Packagist is unreachable (graceful degradation)
- [ ] Verify daemon restart shows correct error message (no typo)
- [ ] Verify `daemon:restart 123` and `daemon:logs 123` use the argument without prompting
- [ ] Verify `logout` asks for confirmation before clearing config

🤖 Generated with [Claude Code](https://claude.com/claude-code)