### PR TITLE
Hide unimplemented command, centralize DB types, improve null safety

### DIFF
--- a/app/Commands/Concerns/InteractsWithDatabase.php
+++ b/app/Commands/Concerns/InteractsWithDatabase.php
@@ -5,6 +5,52 @@ namespace App\Commands\Concerns;
 trait InteractsWithDatabase
 {
     /**
+     * The supported MySQL-compatible database types.
+     *
+     * @var array<string>
+     */
+    protected static array $mysqlTypes = ['mysql', 'mysql8', 'mariadb'];
+
+    /**
+     * The supported PostgreSQL-compatible database types.
+     *
+     * @var array<string>
+     */
+    protected static array $postgresTypes = ['postgres', 'postgres13'];
+
+    /**
+     * Get all supported database types.
+     *
+     * @return array<string>
+     */
+    protected function supportedDatabaseTypes(): array
+    {
+        return array_merge(static::$mysqlTypes, static::$postgresTypes);
+    }
+
+    /**
+     * Determine if the given type is a MySQL-compatible database.
+     *
+     * @param  string  $type
+     * @return bool
+     */
+    protected function isMysqlDatabase(string $type): bool
+    {
+        return in_array($type, static::$mysqlTypes);
+    }
+
+    /**
+     * Determine if the given type is a PostgreSQL-compatible database.
+     *
+     * @param  string  $type
+     * @return bool
+     */
+    protected function isPostgresDatabase(string $type): bool
+    {
+        return in_array($type, static::$postgresTypes);
+    }
+
+    /**
      * Ensures the database service is installed and available on the current server.
      *
      * @return void

--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -49,7 +49,11 @@ trait InteractsWithIO
         abort_if($answers->isEmpty(), 1, 'This server does not have any sites.');
 
         if (! is_null($name)) {
-            return optional($answers->where('name', $name)->first())->id ?: $name;
+            $site = $answers->where('name', $name)->first();
+
+            abort_if(is_null($site), 1, 'The site ['.$name.'] could not be found on this server.');
+
+            return $site->id;
         }
 
         return $this->choiceStep($question, $answers->mapWithKeys(function ($resource) {
@@ -72,7 +76,11 @@ trait InteractsWithIO
         abort_if($answers->isEmpty(), 1, 'This account does not have any servers.');
 
         if (! is_null($name)) {
-            return optional($answers->where('name', $name)->first())->id ?: $name;
+            $server = $answers->where('name', $name)->first();
+
+            abort_if(is_null($server), 1, 'The server ['.$name.'] could not be found.');
+
+            return $server->id;
         }
 
         return $this->choiceStep($question, $answers->mapWithKeys(function ($resource) {

--- a/app/Commands/DaemonStatusCommand.php
+++ b/app/Commands/DaemonStatusCommand.php
@@ -19,6 +19,13 @@ class DaemonStatusCommand extends Command
     protected $description = 'Get the current status of a daemon';
 
     /**
+     * Indicates whether the command should be shown in the Artisan command list.
+     *
+     * @var bool
+     */
+    protected $hidden = true;
+
+    /**
      * Execute the console command.
      *
      * @return void

--- a/app/Commands/DatabaseLogsCommand.php
+++ b/app/Commands/DatabaseLogsCommand.php
@@ -32,7 +32,7 @@ class DatabaseLogsCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $this->currentServer()->databaseType;
 
-        if (! in_array($databaseType, ['mysql', 'mysql8', 'postgres'])) {
+        if (! in_array($databaseType, $this->supportedDatabaseTypes())) {
             abort(1, 'Retrieving logs from ['.$databaseType.'] databases is not supported.');
         }
 

--- a/app/Commands/DatabaseRestartCommand.php
+++ b/app/Commands/DatabaseRestartCommand.php
@@ -34,9 +34,9 @@ class DatabaseRestartCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $server->databaseType;
 
-        if (in_array($databaseType, ['mysql', 'mysql8', 'mariadb'])) {
+        if ($this->isMysqlDatabase($databaseType)) {
             $restarting = $this->restartMysql($server->id);
-        } elseif (in_array($databaseType, ['postgres', 'postgres13'])) {
+        } elseif ($this->isPostgresDatabase($databaseType)) {
             $restarting = $this->restartPostgres($server->id);
         } else {
             abort(1, 'Restarting ['.$databaseType.'] databases is not supported.');

--- a/app/Commands/DatabaseShellCommand.php
+++ b/app/Commands/DatabaseShellCommand.php
@@ -51,9 +51,9 @@ class DatabaseShellCommand extends Command
 
         abort_if(is_null($password), 1, 'Password can not be empty.');
 
-        if (in_array($databaseType, ['mysql', 'mysql8', 'mariadb'])) {
+        if ($this->isMysqlDatabase($databaseType)) {
             return $this->connectToMysql($server->id, $user, $password, $database);
-        } elseif (in_array($databaseType, ['postgres', 'postgres13'])) {
+        } elseif ($this->isPostgresDatabase($databaseType)) {
             return $this->connectToPostgres($server->id, $user, $password, $database);
         }
 

--- a/app/Commands/DatabaseStatusCommand.php
+++ b/app/Commands/DatabaseStatusCommand.php
@@ -34,9 +34,9 @@ class DatabaseStatusCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $server->databaseType;
 
-        if (in_array($databaseType, ['mysql', 'mysql8', 'mariadb'])) {
+        if ($this->isMysqlDatabase($databaseType)) {
             $this->ensureServiceIsRunning($server, 'mysql');
-        } elseif (in_array($databaseType, ['postgres', 'postgres13'])) {
+        } elseif ($this->isPostgresDatabase($databaseType)) {
             $this->ensureServiceIsRunning($server, 'postgres');
         } else {
             abort(1, 'Checking the status of ['.$databaseType.'] databases is not supported.');


### PR DESCRIPTION
Fixes #122, #123, #124

## Summary

- **Hidden command** (#122): `DaemonStatusCommand` appears in `forge list` but immediately aborts with "not yet supported" — now hidden
- **Centralize DB types** (#123): Database type arrays duplicated across 4 commands with inconsistencies — centralized in `InteractsWithDatabase` trait with `isMysqlDatabase()`, `isPostgresDatabase()`, and `supportedDatabaseTypes()` helpers
- **Null safety** (#124): `askForSite()` and `askForServer()` fall back to passing raw name string as API ID when no match found — now shows clear error message instead

## Test plan

- [ ] Verify `daemon:status` no longer appears in `forge list` output
- [ ] Verify all database commands use consistent type lists
- [ ] Verify passing an invalid site/server name shows helpful error message instead of API error

🤖 Generated with [Claude Code](https://claude.com/claude-code)