### PR TITLE
fix: Typo "deamon" in DaemonRestartCommand error message

### DIFF
--- a/app/Commands/DaemonRestartCommand.php
+++ b/app/Commands/DaemonRestartCommand.php
@@ -31,7 +31,7 @@ class DaemonRestartCommand extends Command
 
         $daemon = $this->forge->daemon($server->id, $daemonId);
 
-        abort_unless($daemon->status == 'installed', 1, 'This deamon is not installed or is not running.');
+        abort_unless($daemon->status == 'installed', 1, 'This daemon is not installed or is not running.');
 
         $this->step(['Restarting Daemon %s', $daemon->command]);
 

--- a/tests/Feature/DaemonRestartCommandTest.php
+++ b/tests/Feature/DaemonRestartCommandTest.php
@@ -37,4 +37,4 @@ it('can not restart daemons that are not running', function () {
 
     $this->artisan('daemon:restart')
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Daemon Would You Like To Restart</>', 1);
-})->throws('This deamon is not installed or is not running.');
+})->throws('This daemon is not installed or is not running.');


### PR DESCRIPTION
Fixes #114

Corrects a typo in the error message string passed to `abort_unless` in `DaemonRestartCommand.php` -- "deamon" was misspelled instead of "daemon". The root cause was a simple typo introduced when the error message was originally written. Updates the string in `handle()` and aligns the matching assertion in `DaemonRestartCommandTest.php` to reflect the corrected spelling.