### PR TITLE
[master] [bug] Fix DatabaseLogsCommand missing mariadb and postgres13 types

### DIFF
--- a/app/Commands/DatabaseLogsCommand.php
+++ b/app/Commands/DatabaseLogsCommand.php
@@ -32,7 +32,7 @@ class DatabaseLogsCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $this->currentServer()->databaseType;
 
-        if (! in_array($databaseType, ['mysql', 'mysql8', 'postgres'])) {
+        if (! in_array($databaseType, ['mysql', 'mysql8', 'mariadb', 'postgres', 'postgres13'])) {
             abort(1, 'Retrieving logs from ['.$databaseType.'] databases is not supported.');
         }
 


### PR DESCRIPTION
## Summary
- DatabaseShellCommand, DatabaseRestartCommand, and DatabaseStatusCommand all support `mariadb` and `postgres13`, but DatabaseLogsCommand only checked for `mysql`, `mysql8`, and `postgres`
- This aligns the supported types across all database commands

## Testing
```bash
# On a server with a MariaDB database
forge database:logs
# Should show logs instead of "not supported"

# On a server with PostgreSQL 13
forge database:logs
# Should show logs instead of "not supported"
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.