### PR TITLE
[master] [bug] Fix null reference in CommandCommand

### DIFF
--- a/app/Commands/CommandCommand.php
+++ b/app/Commands/CommandCommand.php
@@ -46,8 +46,10 @@ class CommandCommand extends Command
         do {
             $this->time->sleep(1);
 
-            /** @var \Laravel\Forge\Resources\SiteCommand $command */
+            /** @var \Laravel\Forge\Resources\SiteCommand|null $command */
             $command = collect($this->forge->getSiteCommand($server->id, $siteId, $command->id))->first();
+
+            abort_if(is_null($command), 1, 'The command could not be found.');
         } while ($command->status == 'waiting');
 
         $this->step('Running');
@@ -57,9 +59,11 @@ class CommandCommand extends Command
         $username = $this->forge->site($server->id, $siteId)->username;
 
         $this->displayEventOutput($username, $eventId, function () use ($server, $siteId, &$command) {
+            /** @var \Laravel\Forge\Resources\SiteCommand|null $command */
             $command = collect($this->forge->getSiteCommand($server->id, $siteId, $command->id))->first();
 
-            /** @var \Laravel\Forge\Resources\SiteCommand $command */
+            abort_if(is_null($command), 1, 'The command could not be found.');
+
             return $command->status == 'running';
         });
 


### PR DESCRIPTION
## Summary
- `getSiteCommand()` can return an empty collection
- Calling `->first()` without a null check causes a null reference when accessing `$command->status`
- Adds `abort_if` guards and updates the docblock to reflect the nullable return

## Testing
```bash
# Run a command, then delete the site before it finishes
forge command mysite.com -- "sleep 10"
# Should show "The command could not be found." instead of a null reference error
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.