### PR TITLE
[master] [bug] Fix path logic in InteractsWithLogs for symlinked sites

### DIFF
--- a/app/Commands/Concerns/InteractsWithLogs.php
+++ b/app/Commands/Concerns/InteractsWithLogs.php
@@ -50,7 +50,7 @@ trait InteractsWithLogs
         $sitePath = '/home/'.$site->username.'/'.$site->name;
 
         $sitePath = basename($sitePath) == 'current'
-            ? basename($sitePath)
+            ? dirname($sitePath)
             : $sitePath;
 
         $this->showRemoteLogs(collect($files)->map(function ($file) use ($sitePath) {


### PR DESCRIPTION
## Summary
- When a site path ends with `current` (symlink deployment), `basename()` was used instead of `dirname()`
- This returned just `current` instead of the parent directory, breaking log file resolution

## Testing
```bash
# On a site using symlink/zero-downtime deployment (e.g. Envoyer)
# where the site path is /home/forge/example.com/current
forge site:logs
# Should resolve logs from /home/forge/example.com/current/storage/logs
# instead of trying to read from /current/storage/logs
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.