### PR TITLE
[master] [bug] Fix stray backtick in DaemonLogsCommand signature

### DIFF
--- a/app/Commands/DaemonLogsCommand.php
+++ b/app/Commands/DaemonLogsCommand.php
@@ -12,7 +12,7 @@ class DaemonLogsCommand extends Command
      * @var string
      */
     protected $signature = 'daemon:logs {daemon? : The daemon ID}
-    `                                   {--f|follow : Monitor the log changes in realtime}';
+                                        {--f|follow : Monitor the log changes in realtime}';
 
     /**
      * The description of the command.


### PR DESCRIPTION
## Summary
- A stray backtick character in the command signature breaks Artisan's signature parser
- One character fix

## Testing
```bash
forge daemon:logs --help
# Should show the command help instead of a parse error
```