### PR TITLE
[master] [improvement] Improve null handling in DeployLogsCommand

### DIFF
--- a/app/Commands/DeployLogsCommand.php
+++ b/app/Commands/DeployLogsCommand.php
@@ -31,10 +31,12 @@ class DeployLogsCommand extends Command
 
         $this->step('Retrieving the latest deployment logs');
 
-        $lastDeploymentId = optional(collect($this->forge->siteDeployments(
+        $lastDeployment = collect($this->forge->siteDeployments(
             $this->currentServer()->id,
             $siteId,
-        ))->first())['id'];
+        ))->first();
+
+        $lastDeploymentId = $lastDeployment ? $lastDeployment['id'] : null;
 
         abort_if(is_null($lastDeploymentId), 1, 'This site has not been deployed.');
 


### PR DESCRIPTION
## Summary
- Replace `optional()` with explicit null check for clarity when retrieving the latest deployment ID
- The previous code relied on `optional()`'s ArrayAccess behavior which, while functional, obscured the null handling intent

## Testing
```bash
# On a site with deployments
forge deploy:logs
# Should show the latest deployment log

# On a site with no deployments
forge deploy:logs
# Should show "This site has not been deployed."
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.