### PR TITLE
[master] [security] Fix password exposure in database shell command

### DIFF
--- a/app/Commands/DatabaseShellCommand.php
+++ b/app/Commands/DatabaseShellCommand.php
@@ -72,7 +72,7 @@ class DatabaseShellCommand extends Command
     public function connectToMysql($serverId, $user, $password, $database)
     {
         return $this->remote->passthru(sprintf(
-            'mysql -u %s -p%s %s', $user, $password, $database
+            'MYSQL_PWD=%s mysql -u %s %s', escapeshellarg($password), escapeshellarg($user), escapeshellarg($database)
         ));
     }
 
@@ -88,7 +88,7 @@ class DatabaseShellCommand extends Command
     public function connectToPostgres($serverId, $user, $password, $database)
     {
         return $this->remote->passthru(sprintf(
-            'PGPASSWORD=%s psql -U %s %s', $password, $user, $database
+            'PGPASSWORD=%s psql -U %s %s', escapeshellarg($password), escapeshellarg($user), escapeshellarg($database)
         ));
     }
 }

--- a/tests/Feature/DatabaseShellCommandTest.php
+++ b/tests/Feature/DatabaseShellCommandTest.php
@@ -10,7 +10,7 @@ it('can open shell connections to mysql databases', function () {
     ]);
 
     $this->remote->shouldReceive('passthru')
-        ->with('mysql -u forge -pmy-secret-password forge-default-database')
+        ->with("MYSQL_PWD='my-secret-password' mysql -u 'forge' 'forge-default-database'")
         ->andReturn(0);
 
     $this->artisan('database:shell')
@@ -28,7 +28,7 @@ it('can open shell connections to postgres databases', function () {
     ]);
 
     $this->remote->shouldReceive('passthru')
-        ->with('PGPASSWORD=my-secret-password psql -U forge forge-default-database')
+        ->with("PGPASSWORD='my-secret-password' psql -U 'forge' 'forge-default-database'")
         ->andReturn(0);
 
     $this->artisan('database:shell')
@@ -46,7 +46,7 @@ test('exit code gets returned', function () {
     ]);
 
     $this->remote->shouldReceive('passthru')
-        ->with('mysql -u forge -pmy-wrong-secret-password forge-default-database')
+        ->with("MYSQL_PWD='my-wrong-secret-password' mysql -u 'forge' 'forge-default-database'")
         ->andReturn(1);
 
     $this->artisan('database:shell')
@@ -61,7 +61,7 @@ it('can open shell connections with custom database name and user', function () 
     );
 
     $this->remote->shouldReceive('passthru')
-        ->with('PGPASSWORD=my-secret-password psql -U my-user my-database')
+        ->with("PGPASSWORD='my-secret-password' psql -U 'my-user' 'my-database'")
         ->andReturn(0);
 
     $this->artisan('database:shell', ['database' => 'my-database', '--user' => 'my-user'])


### PR DESCRIPTION
## Summary
- MySQL connection used `-p` flag which exposed the password in the process list
- Switched to `MYSQL_PWD` environment variable approach
- Added `escapeshellarg()` to password, user, and database arguments in both MySQL and PostgreSQL connection methods

### Before
```bash
# Password visible in ps output
mysql -u forge -pS3cretP@ss forge_db
```

### After
```bash
# Password hidden from process list
MYSQL_PWD='S3cretP@ss' mysql -u 'forge' 'forge_db'
```

### Note on MYSQL_PWD
`MYSQL_PWD` is marked as deprecated in MySQL 8.0+ docs, but it remains functional in all current MySQL versions (including 8.4+) with no removal timeline. The alternative (`--defaults-extra-file`) requires writing a temp file to disk with the password, which is arguably a worse security trade-off. The `PGPASSWORD` approach for PostgreSQL (already used in this codebase) follows the same pattern.

## Testing
```bash
# MySQL database
forge database:shell
# Enter password with special characters (e.g. p@ss'w0rd!)
# Should connect successfully

# While connected, check from another terminal:
ps aux | grep mysql
# Password should NOT appear in the process list

# PostgreSQL database
forge database:shell
# Should connect with escapeshellarg'd credentials
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.