### PR TITLE
[master] [bug] Add error handling to version check

### DIFF
--- a/app/Commands/Concerns/InteractsWithVersions.php
+++ b/app/Commands/Concerns/InteractsWithVersions.php
@@ -33,12 +33,28 @@ trait InteractsWithVersions
     protected function getLatestVersion()
     {
         $resolver = static::$latestVersionResolver ?? function () {
-            $package = json_decode(file_get_contents(
-                'https://packagist.org/p2/laravel/forge-cli.json'
-            ), true);
+            try {
+                $context = stream_context_create([
+                    'http' => ['timeout' => 5],
+                ]);
 
-            return collect($package['packages']['laravel/forge-cli'])
-                ->first()['version'];
+                $response = file_get_contents(
+                    'https://packagist.org/p2/laravel/forge-cli.json',
+                    false,
+                    $context
+                );
+
+                if ($response === false) {
+                    return 'v'.config('app.version');
+                }
+
+                $package = json_decode($response, true);
+
+                return collect($package['packages']['laravel/forge-cli'])
+                    ->first()['version'];
+            } catch (\Throwable $e) {
+                return 'v'.config('app.version');
+            }
         };
 
         if (is_null($this->config->get('latest_version_verified_at'))) {


### PR DESCRIPTION
## Summary
- Version check fetches from packagist.org without timeout or error handling
- If the request fails or times out, the CLI crashes
- Wraps the call in a try/catch with a 5-second timeout, falling back to the current version on failure

## Testing
```bash
# With internet access
forge list
# Should work normally, showing version warning if outdated

# Without internet (e.g. airplane mode or block packagist.org)
forge list
# Should work normally without crashing - silently skips version check
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.