### PR TITLE
[master] [bug] Support daemon ID argument in daemon commands

### DIFF
--- a/app/Commands/DaemonLogsCommand.php
+++ b/app/Commands/DaemonLogsCommand.php
@@ -28,7 +28,7 @@ class DaemonLogsCommand extends Command
      */
     public function handle()
     {
-        $daemonId = $this->askForDaemon('Which daemon would you like to retrieve the logs from');
+        $daemonId = $this->argument('daemon') ?? $this->askForDaemon('Which daemon would you like to retrieve the logs from');
 
         $daemon = $this->forge->daemon($this->currentServer()->id, $daemonId);
 

--- a/app/Commands/DaemonRestartCommand.php
+++ b/app/Commands/DaemonRestartCommand.php
@@ -27,7 +27,7 @@ class DaemonRestartCommand extends Command
     {
         $server = $this->currentServer();
 
-        $daemonId = $this->askForDaemon('Which daemon would you like to restart');
+        $daemonId = $this->argument('daemon') ?? $this->askForDaemon('Which daemon would you like to restart');
 
         $daemon = $this->forge->daemon($server->id, $daemonId);
 


### PR DESCRIPTION
## Summary
- `DaemonLogsCommand` and `DaemonRestartCommand` define a daemon argument in their signature but never check it
- Always falls through to the interactive prompt
- This checks `argument('daemon')` first, enabling non-interactive usage

## Testing
```bash
# Non-interactive (new behavior)
forge daemon:logs 12345
# Should show logs without prompting

forge daemon:restart 12345
# Should restart without prompting

# Interactive (preserved behavior)
forge daemon:logs
# Should prompt "Which daemon would you like to retrieve the logs from"

forge daemon:restart
# Should prompt "Which daemon would you like to restart"
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.