### PR TITLE
[master] [improvement] Add confirmation prompt to logout command

### DIFF
--- a/app/Commands/LogoutCommand.php
+++ b/app/Commands/LogoutCommand.php
@@ -25,7 +25,7 @@ class LogoutCommand extends Command
      */
     public function handle()
     {
-        if (! $this->option('force') && ! $this->confirmStep('Are you sure you want to log out? This will remove your stored API token and configuration')) {
+        if (! $this->option('force') && ! $this->option('no-interaction') && ! $this->confirmStep('Are you sure you want to log out? This will remove your stored API token and configuration')) {
             return;
         }
 

--- a/app/Commands/LogoutCommand.php
+++ b/app/Commands/LogoutCommand.php
@@ -16,7 +16,7 @@ class LogoutCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Logout from Laravel Forge';
+    protected $description = 'Logout from Laravel Forge and remove your stored API token and server configuration';
 
     /**
      * Execute the console command.

--- a/app/Commands/LogoutCommand.php
+++ b/app/Commands/LogoutCommand.php
@@ -9,7 +9,7 @@ class LogoutCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'logout';
+    protected $signature = 'logout {--force : Skip confirmation prompt}';
 
     /**
      * The description of the command.
@@ -25,7 +25,7 @@ class LogoutCommand extends Command
      */
     public function handle()
     {
-        if (! $this->confirmStep('Are you sure you want to log out? This will remove your stored API token and configuration')) {
+        if (! $this->option('force') && ! $this->confirmStep('Are you sure you want to log out? This will remove your stored API token and configuration')) {
             return;
         }
 

--- a/app/Commands/LogoutCommand.php
+++ b/app/Commands/LogoutCommand.php
@@ -25,6 +25,10 @@ class LogoutCommand extends Command
      */
     public function handle()
     {
+        if (! $this->confirmStep('Are you sure you want to log out? This will remove your stored API token and configuration')) {
+            return;
+        }
+
         $this->config->flush();
 
         $this->successfulStep('Logged Out Successfully');

--- a/app/Commands/LogoutCommand.php
+++ b/app/Commands/LogoutCommand.php
@@ -16,7 +16,7 @@ class LogoutCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Logout from Laravel Forge and remove your stored API token and server configuration';
+    protected $description = 'Log out from Laravel Forge';
 
     /**
      * Execute the console command.

--- a/tests/Feature/LogoutCommandTest.php
+++ b/tests/Feature/LogoutCommandTest.php
@@ -2,6 +2,7 @@
 
 it('logout users', function () {
     $this->artisan('logout')
+        ->expectsQuestion('<fg=yellow>‣</> <options=bold>Are You Sure You Want To Log Out? This Will Remove Your Stored API Token And Configuration</>', 'yes')
         ->expectsOutput('==> Logged Out Successfully');
 
     expect($this->config->get('server'))->toBeNull();


### PR DESCRIPTION
## Summary
- The logout command immediately flushes all config (API token, server context) without confirmation
- Adds a `confirmStep` prompt to prevent accidental logouts
- Adds `--force` flag to skip the prompt for scripted usage
- `--no-interaction` also skips the prompt to preserve backwards compatibility

## Before
```
$ forge logout
==> Logged Out Successfully
```

## After
```
$ forge logout
  ‣ Are You Sure You Want To Log Out? This Will Remove Your Stored API Token And Configuration (yes/no) [no]

$ forge logout --force
==> Logged Out Successfully

$ forge logout --no-interaction
==> Logged Out Successfully
```

## Testing
```bash
# Interactive - confirm
forge logout
# Answer "yes" -> logs out
# Answer "no" -> cancels

# Scripted
forge logout --force
# Logs out without prompting

# Backwards compatible
forge logout --no-interaction
# Logs out without prompting (same as before this change)

# Help
forge logout --help
# Shows --force option
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.