### PR TITLE
[master] [improvement] Hide unimplemented DaemonStatusCommand

### DIFF
--- a/app/Commands/DaemonStatusCommand.php
+++ b/app/Commands/DaemonStatusCommand.php
@@ -19,6 +19,13 @@ class DaemonStatusCommand extends Command
     protected $description = 'Get the current status of a daemon';
 
     /**
+     * Indicates whether the command should be shown in the Artisan command list.
+     *
+     * @var bool
+     */
+    protected $hidden = true;
+
+    /**
      * Execute the console command.
      *
      * @return void


### PR DESCRIPTION
## Summary
- `DaemonStatusCommand` immediately aborts with "not yet available"
- Hiding it from the command list prevents user confusion while keeping it available for future implementation
- See #142 for implementing the command

## Before
```
$ forge list
  daemon:list      List the daemons
  daemon:logs      Retrieve the latest daemon log messages
  daemon:restart   Restart a daemon
  daemon:status    Get the current status of a daemon

$ forge daemon:status
  Checking a daemon's status is not yet supported
```

## After
```
$ forge list
  daemon:list      List the daemons
  daemon:logs      Retrieve the latest daemon log messages
  daemon:restart   Restart a daemon

$ forge daemon:status
  Checking a daemon's status is not yet supported
```

The command is hidden from the list but still callable directly - same behavior, just no longer advertised to users.

## Testing
```bash
forge list
# daemon:status should NOT appear in the command list

forge daemon:status
# Should still work (shows "not yet available")
```