### PR TITLE
[master] [improvement] Centralize database type definitions

### DIFF
--- a/app/Commands/Concerns/InteractsWithDatabase.php
+++ b/app/Commands/Concerns/InteractsWithDatabase.php
@@ -5,6 +5,52 @@ namespace App\Commands\Concerns;
 trait InteractsWithDatabase
 {
     /**
+     * The supported MySQL-compatible database types.
+     *
+     * @var array<string>
+     */
+    protected static array $mysqlTypes = ['mysql', 'mysql8', 'mariadb'];
+
+    /**
+     * The supported PostgreSQL-compatible database types.
+     *
+     * @var array<string>
+     */
+    protected static array $postgresTypes = ['postgres', 'postgres13'];
+
+    /**
+     * Get all supported database types.
+     *
+     * @return array<string>
+     */
+    protected function supportedDatabaseTypes(): array
+    {
+        return array_merge(static::$mysqlTypes, static::$postgresTypes);
+    }
+
+    /**
+     * Determine if the given type is a MySQL-compatible database.
+     *
+     * @param  string  $type
+     * @return bool
+     */
+    protected function isMysqlDatabase(string $type): bool
+    {
+        return in_array($type, static::$mysqlTypes);
+    }
+
+    /**
+     * Determine if the given type is a PostgreSQL-compatible database.
+     *
+     * @param  string  $type
+     * @return bool
+     */
+    protected function isPostgresDatabase(string $type): bool
+    {
+        return in_array($type, static::$postgresTypes);
+    }
+
+    /**
      * Ensures the database service is installed and available on the current server.
      *
      * @return void

--- a/app/Commands/DatabaseLogsCommand.php
+++ b/app/Commands/DatabaseLogsCommand.php
@@ -32,7 +32,7 @@ class DatabaseLogsCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $this->currentServer()->databaseType;
 
-        if (! in_array($databaseType, ['mysql', 'mysql8', 'postgres'])) {
+        if (! in_array($databaseType, $this->supportedDatabaseTypes())) {
             abort(1, 'Retrieving logs from ['.$databaseType.'] databases is not supported.');
         }
 

--- a/app/Commands/DatabaseRestartCommand.php
+++ b/app/Commands/DatabaseRestartCommand.php
@@ -34,9 +34,9 @@ class DatabaseRestartCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $server->databaseType;
 
-        if (in_array($databaseType, ['mysql', 'mysql8', 'mariadb'])) {
+        if ($this->isMysqlDatabase($databaseType)) {
             $restarting = $this->restartMysql($server->id);
-        } elseif (in_array($databaseType, ['postgres', 'postgres13'])) {
+        } elseif ($this->isPostgresDatabase($databaseType)) {
             $restarting = $this->restartPostgres($server->id);
         } else {
             abort(1, 'Restarting ['.$databaseType.'] databases is not supported.');

--- a/app/Commands/DatabaseShellCommand.php
+++ b/app/Commands/DatabaseShellCommand.php
@@ -51,9 +51,9 @@ class DatabaseShellCommand extends Command
 
         abort_if(is_null($password), 1, 'Password can not be empty.');
 
-        if (in_array($databaseType, ['mysql', 'mysql8', 'mariadb'])) {
+        if ($this->isMysqlDatabase($databaseType)) {
             return $this->connectToMysql($server->id, $user, $password, $database);
-        } elseif (in_array($databaseType, ['postgres', 'postgres13'])) {
+        } elseif ($this->isPostgresDatabase($databaseType)) {
             return $this->connectToPostgres($server->id, $user, $password, $database);
         }
 

--- a/app/Commands/DatabaseStatusCommand.php
+++ b/app/Commands/DatabaseStatusCommand.php
@@ -34,9 +34,9 @@ class DatabaseStatusCommand extends Command
         // @phpstan-ignore-next-line
         $databaseType = $server->databaseType;
 
-        if (in_array($databaseType, ['mysql', 'mysql8', 'mariadb'])) {
+        if ($this->isMysqlDatabase($databaseType)) {
             $this->ensureServiceIsRunning($server, 'mysql');
-        } elseif (in_array($databaseType, ['postgres', 'postgres13'])) {
+        } elseif ($this->isPostgresDatabase($databaseType)) {
             $this->ensureServiceIsRunning($server, 'postgres');
         } else {
             abort(1, 'Checking the status of ['.$databaseType.'] databases is not supported.');


### PR DESCRIPTION
## Summary
- Database type arrays were duplicated across DatabaseShellCommand, DatabaseRestartCommand, DatabaseStatusCommand, and DatabaseLogsCommand with inconsistent values
- Centralizes them in the `InteractsWithDatabase` trait with helper methods `isMysqlDatabase()` and `isPostgresDatabase()`
- All commands now support the same types: mysql, mysql8, mariadb, postgres, postgres13

## Testing
```bash
# Verify all database commands accept the same types
forge database:shell     # mysql, mysql8, mariadb, postgres, postgres13
forge database:restart   # same
forge database:status    # same
forge database:logs      # same (previously missing mariadb, postgres13)
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.