### PR TITLE
[master] [bug] Fix null safety in askForSite and askForServer

### DIFF
--- a/app/Commands/Concerns/InteractsWithIO.php
+++ b/app/Commands/Concerns/InteractsWithIO.php
@@ -49,7 +49,8 @@ trait InteractsWithIO
         abort_if($answers->isEmpty(), 1, 'This server does not have any sites.');
 
         if (! is_null($name)) {
-            return optional($answers->where('name', $name)->first())->id ?: $name;
+            $site = $answers->where('name', $name)->first();
+            return $site ? $site->id : $name;
         }
 
         return $this->choiceStep($question, $answers->mapWithKeys(function ($resource) {
@@ -72,7 +73,8 @@ trait InteractsWithIO
         abort_if($answers->isEmpty(), 1, 'This account does not have any servers.');
 
         if (! is_null($name)) {
-            return optional($answers->where('name', $name)->first())->id ?: $name;
+            $server = $answers->where('name', $name)->first();
+            return $server ? $server->id : $name;
         }
 
         return $this->choiceStep($question, $answers->mapWithKeys(function ($resource) {


### PR DESCRIPTION
## Summary
- When a site or server name is passed that doesn't match any results, `optional()->id` returns null
- This null is silently passed as the ID to subsequent API calls, causing opaque errors
- Replaces the `optional()` pattern with an explicit ternary that returns the matched ID or falls back to the raw value (which may be a numeric ID)

## Testing
```bash
# Pass a valid site name
forge deploy mysite.com
# Should resolve the site and deploy

# Pass a numeric site ID
forge deploy 12345
# Should use the ID directly (backwards compatible)

# Interactive prompt (no argument)
forge deploy
# Should prompt as before
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.