### PR TITLE
[master] [bug] Check file existence before site resolution in EnvPushCommand

### DIFF
--- a/app/Commands/EnvPushCommand.php
+++ b/app/Commands/EnvPushCommand.php
@@ -29,6 +29,14 @@ class EnvPushCommand extends Command
      */
     public function handle()
     {
+        if ($file = $this->argument('file')) {
+            abort_unless(
+                File::exists($file),
+                1,
+                "The file [{$file}] does not exist."
+            );
+        }
+
         $siteId = $this->askForSite('Which site would you like to upload the environment file to');
 
         $server = $this->currentServer();

--- a/tests/Feature/EnvPushCommandTest.php
+++ b/tests/Feature/EnvPushCommandTest.php
@@ -48,7 +48,7 @@ it('can push environment variables from specific env file', function () {
         (object) ['id' => 2, 'name' => 'something.com'],
     );
 
-    File::shouldReceive('exists')->once()->with('.env')->andReturn(true);
+    File::shouldReceive('exists')->twice()->with('.env')->andReturn(true);
 
     $content = "BAR=FOO\nFOO=BAR\n";
 


### PR DESCRIPTION
## Summary
- When a file argument is provided to `env:push`, the existence check happens after site selection and API calls
- If the file doesn't exist, the user has already gone through the interactive prompt and server resolution for nothing
- Adds an early check when a file argument is explicitly provided

## Testing
```bash
# File doesn't exist - should fail immediately
forge env:push mysite nonexistent.env
# Should show "The file [nonexistent.env] does not exist." without prompting for site

# File exists - normal flow
forge env:push mysite .env
# Should proceed to upload

# No file argument - default flow unchanged
forge env:push
# Should prompt for site and use generated file
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.