### PR TITLE
[master] [bug] Fix cross-platform browser opening in OpenCommand

### DIFF
--- a/app/Commands/OpenCommand.php
+++ b/app/Commands/OpenCommand.php
@@ -37,7 +37,7 @@ class OpenCommand extends Command
         $command = match (PHP_OS_FAMILY) {
             'Darwin' => ['open', $url],
             'Linux' => ['xdg-open', $url],
-            'Windows' => ['rundll32', 'url.dll,FileProtocolHandler', $url],
+            'Windows' => ['cmd', '/c', 'start', '', $url],
             default => null,
         };
 

--- a/app/Commands/OpenCommand.php
+++ b/app/Commands/OpenCommand.php
@@ -34,21 +34,20 @@ class OpenCommand extends Command
 
         $url = "https://forge.laravel.com/servers/$serverId/sites/$siteId";
 
-        $os = strtolower(php_uname(PHP_OS));
+        $command = match (PHP_OS_FAMILY) {
+            'Darwin' => ['open', $url],
+            'Linux' => ['xdg-open', $url],
+            'Windows' => ['rundll32', 'url.dll,FileProtocolHandler', $url],
+            default => null,
+        };
 
-        if (strpos($os, 'darwin') !== false) {
-            $open = 'open';
-        } elseif (strpos($os, 'linux') !== false) {
-            $open = 'xdg-open';
-        } else {
+        if ($command === null) {
             $this->step("Can't open your browser, you'll have to manually navigate to {$url}");
 
             return;
         }
 
         $this->step('Opening site in your browser...');
-
-        $command = [$open, $url];
 
         $process = new Process($command);
         $process->run();


### PR DESCRIPTION
## Summary
- Uses `PHP_OS_FAMILY` constant instead of `php_uname(PHP_OS)` which throws a ValueError on PHP 8.4+ (fixes #106)
- Adds Windows support using `cmd /c start` (previously showed "Can't open your browser" on Windows)
- Simplifies OS detection with match expression

Inspired by laravel/cloud-cli#117.

## Testing
```bash
# macOS
forge open
# Should open the site URL in default browser via `open`

# Linux
forge open
# Should open via `xdg-open`

# Windows
forge open
# Should open via `cmd /c start` (previously showed "Can't open your browser")

# PHP 8.4+
forge open
# Should work without ValueError (previously crashed with php_uname() error)
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead. The Windows `cmd /c start` approach has been verified locally to open URLs in the default browser.