### PR TITLE
[master] [feature] Implement daemon:status command

### DIFF
--- a/app/Commands/DaemonStatusCommand.php
+++ b/app/Commands/DaemonStatusCommand.php
@@ -25,6 +25,36 @@ class DaemonStatusCommand extends Command
      */
     public function handle()
     {
-        abort(1, 'Checking a daemon\'s status is not yet supported');
+        $daemonId = $this->argument('daemon') ?? $this->askForDaemon('Which daemon would you like to check the status of');
+
+        $daemon = $this->forge->daemon($this->currentServer()->id, $daemonId);
+
+        abort_if(is_null($daemon), 1, 'The daemon could not be found.');
+
+        $this->step(['Daemon Status: %s', $daemon->command]);
+
+        $this->table([], [
+            ['ID', $daemon->id],
+            ['Command', '<fg=blue>'.$daemon->command.'</>'],
+            ['Status', $this->formatStatus($daemon->status)],
+            ['User', $daemon->user],
+            ['Directory', $daemon->directory ?: '-'],
+            ['Created', $daemon->createdAt],
+        ]);
+    }
+
+    /**
+     * Format the daemon status with color.
+     *
+     * @param  string  $status
+     * @return string
+     */
+    protected function formatStatus($status)
+    {
+        return match ($status) {
+            'installed' => '<fg=green>'.ucfirst($status).'</>',
+            'installing' => '<fg=yellow>'.ucfirst($status).'</>',
+            default => '<fg=red>'.ucfirst($status).'</>',
+        };
     }
 }

--- a/tests/Feature/DaemonStatusCommandTest.php
+++ b/tests/Feature/DaemonStatusCommandTest.php
@@ -1,5 +1,46 @@
 <?php
 
-it('can not retrieve a daemon status yet')
-    ->artisan('daemon:status')
-    ->throws('Checking a daemon\'s status is not yet supported');
+it('can retrieve a daemon status', function () {
+    $this->client->shouldReceive('server')->andReturn(
+        (object) ['id' => 1, 'name' => 'production'],
+    );
+
+    $this->client->shouldReceive('daemons')->andReturn([
+        (object) ['id' => 1, 'command' => 'php artisan queue:work'],
+    ]);
+
+    $this->client->shouldReceive('daemon')->with(1, 1)->andReturn(
+        (object) [
+            'id' => 1,
+            'command' => 'php artisan queue:work',
+            'status' => 'installed',
+            'user' => 'forge',
+            'directory' => '/home/forge/example.com',
+            'createdAt' => '2024-01-01 00:00:00',
+        ],
+    );
+
+    $this->artisan('daemon:status')
+        ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Daemon Would You Like To Check The Status Of</>', 1)
+        ->expectsOutput('==> Daemon Status: [php artisan queue:work]');
+});
+
+it('can retrieve a daemon status with an argument', function () {
+    $this->client->shouldReceive('server')->andReturn(
+        (object) ['id' => 1, 'name' => 'production'],
+    );
+
+    $this->client->shouldReceive('daemon')->with(1, 1)->andReturn(
+        (object) [
+            'id' => 1,
+            'command' => 'php artisan queue:work',
+            'status' => 'installed',
+            'user' => 'forge',
+            'directory' => '/home/forge/example.com',
+            'createdAt' => '2024-01-01 00:00:00',
+        ],
+    );
+
+    $this->artisan('daemon:status', ['daemon' => 1])
+        ->expectsOutput('==> Daemon Status: [php artisan queue:work]');
+});


### PR DESCRIPTION
## Summary
- Implements the `daemon:status` command which was previously a stub that aborted with "not yet available"
- Displays daemon details: ID, command, status, user, directory, and creation date
- Status is color-coded: green for installed, yellow for installing, red for failed/other
- Supports both interactive daemon selection and direct ID argument (`forge daemon:status 12345`)

Fixes #142

## Testing
```bash
# Interactive
forge daemon:status
# Prompts to select a daemon, then displays its details

# Direct ID
forge daemon:status 12345
# Displays the daemon's details without prompting
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.