### PR TITLE
[master] [bug] Fix DeployCommandTest for siteDeploymentOutput

### DIFF
--- a/tests/Feature/DeployCommandTest.php
+++ b/tests/Feature/DeployCommandTest.php
@@ -16,38 +16,20 @@ it('can deploy sites with an menu', function () {
 
     $this->client->shouldReceive('deploySite')->with(1, 1, false)->once()->andReturn(null);
 
-    $this->client->shouldReceive('events')->with(1)->once()->andReturn([
-        (object) ['id' => 3, 'description' => 'Deploying Pushed Code (pestphp.com).'],
-        (object) ['id' => 2, 'description' => 'Deploying Pushed Code (something.com).'],
-        (object) ['id' => 1, 'description' => 'Deploying Pushed Code (pestphp.com).'],
-    ]);
-
     $this->client->shouldReceive('siteDeployments')->with(1, 1)->once()->andReturn([
         ['id' => 3],
     ]);
-
-    $this->remote->shouldReceive('exec')->with(
-        'cat /home/forge/.forge/provision-3.output'
-    )->once()->andReturn([0, [
-        'Installing composer dependencies...',
-    ]]);
-
-    $this->remote->shouldReceive('exec')->with(
-        'cat /home/forge/.forge/provision-3.output'
-    )->once()->andReturn([0, [
-        'Installing composer dependencies...',
-        'Restarting FPM...',
-    ]]);
 
     $this->client->shouldReceive('siteDeployment')->with(1, 1, 3)->once()->andReturn(
         (object) ['id' => 3, 'status' => 'finished', 'started_at' => '2021-07-20 12:50:01', 'ended_at' => '2021-07-20 12:50:09'],
     );
 
+    $this->client->shouldReceive('siteDeploymentOutput')->with(1, 1, 3)->once()->andReturn("Installing composer dependencies...\nRestarting FPM...");
+
     $this->artisan('deploy')
         ->expectsQuestion('<fg=yellow>‣</> <options=bold>Which Site Would You Like To Deploy</>', 1)
         ->expectsOutput('==> Queuing Deployment')
         ->expectsOutput('==> Waiting For Deployment To Start')
-        ->expectsOutput('==> Deploying')
         ->expectsOutput('  ▕ Installing composer dependencies...')
         ->expectsOutput('  ▕ Restarting FPM...')
         ->expectsOutput('==> Site Deployed Successfully. (8s)');
@@ -69,37 +51,19 @@ it('can deploy sites with an option', function () {
 
     $this->client->shouldReceive('deploySite')->with(1, 2, false)->once()->andReturn(null);
 
-    $this->client->shouldReceive('events')->with(1)->once()->andReturn([
-        (object) ['id' => 3, 'description' => 'Deploying Pushed Code (something.com).'],
-        (object) ['id' => 2, 'description' => 'Deploying Pushed Code (something.com).'],
-        (object) ['id' => 1, 'description' => 'Deploying Pushed Code (pestphp.com).'],
-    ]);
-
     $this->client->shouldReceive('siteDeployments')->with(1, 2)->once()->andReturn([
         ['id' => 3],
     ]);
-
-    $this->remote->shouldReceive('exec')->with(
-        'cat /home/forge/.forge/provision-3.output'
-    )->once()->andReturn([0, [
-        'Installing composer dependencies...',
-    ]]);
-
-    $this->remote->shouldReceive('exec')->with(
-        'cat /home/forge/.forge/provision-3.output'
-    )->once()->andReturn([0, [
-        'Installing composer dependencies...',
-        'Restarting FPM...',
-    ]]);
 
     $this->client->shouldReceive('siteDeployment')->with(1, 2, 3)->once()->andReturn(
         (object) ['id' => 3, 'status' => 'finished', 'started_at' => '2021-07-20 12:50:01', 'ended_at' => '2021-07-20 12:50:09'],
     );
 
+    $this->client->shouldReceive('siteDeploymentOutput')->with(1, 2, 3)->once()->andReturn("Installing composer dependencies...\nRestarting FPM...");
+
     $this->artisan('deploy', ['site' => 2])
         ->expectsOutput('==> Queuing Deployment')
         ->expectsOutput('==> Waiting For Deployment To Start')
-        ->expectsOutput('==> Deploying')
         ->expectsOutput('  ▕ Installing composer dependencies...')
         ->expectsOutput('  ▕ Restarting FPM...')
         ->expectsOutput('==> Site Deployed Successfully. (8s)');
@@ -121,37 +85,19 @@ it('can deploy sites when sites use website isolation', function () {
 
     $this->client->shouldReceive('deploySite')->with(1, 2, false)->once()->andReturn(null);
 
-    $this->client->shouldReceive('events')->with(1)->once()->andReturn([
-        (object) ['id' => 3, 'description' => 'Deploying Pushed Code (something.com).'],
-        (object) ['id' => 2, 'description' => 'Deploying Pushed Code (something.com).'],
-        (object) ['id' => 1, 'description' => 'Deploying Pushed Code (pestphp.com).'],
-    ]);
-
     $this->client->shouldReceive('siteDeployments')->with(1, 2)->once()->andReturn([
         ['id' => 3],
     ]);
-
-    $this->remote->shouldReceive('exec')->with(
-        'cat /home/user-in-isolation/.forge/provision-3.output'
-    )->once()->andReturn([0, [
-        'Installing composer dependencies...',
-    ]]);
-
-    $this->remote->shouldReceive('exec')->with(
-        'cat /home/user-in-isolation/.forge/provision-3.output'
-    )->once()->andReturn([0, [
-        'Installing composer dependencies...',
-        'Restarting FPM...',
-    ]]);
 
     $this->client->shouldReceive('siteDeployment')->with(1, 2, 3)->once()->andReturn(
         (object) ['id' => 3, 'status' => 'finished', 'started_at' => '2021-07-20 12:50:01', 'ended_at' => '2021-07-20 12:50:09'],
     );
 
+    $this->client->shouldReceive('siteDeploymentOutput')->with(1, 2, 3)->once()->andReturn("Installing composer dependencies...\nRestarting FPM...");
+
     $this->artisan('deploy', ['site' => 2])
         ->expectsOutput('==> Queuing Deployment')
         ->expectsOutput('==> Waiting For Deployment To Start')
-        ->expectsOutput('==> Deploying')
         ->expectsOutput('  ▕ Installing composer dependencies...')
         ->expectsOutput('  ▕ Restarting FPM...')
         ->expectsOutput('==> Site Deployed Successfully. (8s)');
@@ -190,30 +136,15 @@ it('handles deployment failures', function () {
 
     $this->client->shouldReceive('deploySite')->with(1, 2, false)->once()->andReturn(null);
 
-    $this->client->shouldReceive('events')->with(1)->once()->andReturn([
-        (object) ['id' => 3, 'description' => 'Deploying Pushed Code (something.com).'],
-        (object) ['id' => 2, 'description' => 'Deploying Pushed Code (something.com).'],
-        (object) ['id' => 1, 'description' => 'Deploying Pushed Code (pestphp.com).'],
-    ]);
-
     $this->client->shouldReceive('siteDeployments')->with(1, 2)->once()->andReturn([
         ['id' => 3],
     ]);
 
-    $this->remote->shouldReceive('exec')->with(
-        'cat /home/forge/.forge/provision-3.output'
-    )->once()->andReturn([0, ['Installing composer dependencies...']]);
-
-    $this->remote->shouldReceive('exec')->with(
-        'cat /home/forge/.forge/provision-3.output'
-    )->once()->andReturn([0, [
-        'Installing composer dependencies...',
-        'Restarting FPM failed...',
-    ]]);
-
     $this->client->shouldReceive('siteDeployment')->with(1, 2, 3)->once()->andReturn(
         (object) ['id' => 3, 'status' => 'failed', 'started_at' => '2021-07-20 12:50:01', 'ended_at' => '2021-07-20 12:50:09'],
     );
+
+    $this->client->shouldReceive('siteDeploymentOutput')->with(1, 2, 3)->once()->andReturn("Installing composer dependencies...\nRestarting FPM failed...");
 
     $this->artisan('deploy', ['site' => 2]);
 })->throws('The deployment failed.');


### PR DESCRIPTION
## Summary
- `DeployCommand` calls `siteDeploymentOutput()` to display deployment output, but the tests never mocked this method
- The deploy flow also no longer uses SSH polling via `remote->exec()` or `events()` for output, but the tests still mocked these removed calls
- This updates the tests to match the current deploy flow:
  - Adds `siteDeploymentOutput` mock with expected output
  - Removes stale `events()` mocks (no longer called)
  - Removes stale `remote->exec()` mocks (SSH polling replaced by API call)

### Before
```
Tests: 4 failed, 98 passed
```

### After
```
Tests: 102 passed
```

## Testing
```bash
vendor/bin/pest --filter="DeployCommandTest"
# All 5 tests should pass
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.