### PR TITLE
[master] Upgrade to Laravel Zero 12

### DIFF
--- a/app/Commands/Command.php
+++ b/app/Commands/Command.php
@@ -89,7 +89,7 @@ abstract class Command extends BaseCommand
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         return tap(parent::execute($input, $output), function () {
             $this->ensureLatestVersion();

--- a/app/Commands/ServerSwitchCommand.php
+++ b/app/Commands/ServerSwitchCommand.php
@@ -2,7 +2,7 @@
 
 namespace App\Commands;
 
-use Spatie\Once;
+use Illuminate\Support\Once;
 
 class ServerSwitchCommand extends Command
 {
@@ -42,7 +42,7 @@ class ServerSwitchCommand extends Command
 
         $this->config->set('server', $server->id);
 
-        Once\Cache::getInstance()->flush();
+        Once::flush();
 
         $this->successfulStep(
             'Current server context changed successfully to <comment>['.$server->name.']</comment>'

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,15 @@
         }
     ],
     "require": {
-        "php": "^8.1.0",
+        "php": "^8.2",
         "phpseclib/phpseclib": "^3.0.19"
     },
     "require-dev": {
-        "laravel-zero/framework": "^10.0.2",
+        "laravel-zero/framework": "^12.0",
         "laravel/forge-sdk": "^3.13.4",
         "mockery/mockery": "^1.5.1",
-        "larastan/larastan": "^2.6.0",
-        "pestphp/pest": "^2.6.1",
-        "spatie/once": "^3.1.0"
+        "larastan/larastan": "^3.0",
+        "pestphp/pest": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,7 +37,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.1.0"
+            "php": "8.2"
         },
         "allow-plugins": {
             "pestphp/pest-plugin": true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,5 +10,3 @@ parameters:
   ignoreErrors:
     - '#Unsafe usage of new static\(\)#'
     - '#does not have argument#'
-  checkMissingIterableValueType: false
-  checkGenericClassInNonGenericObjectType: false

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,7 +9,7 @@ use App\Repositories\RemoteRepository;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
 use LaravelZero\Framework\Testing\TestCase;
-use Spatie\Once;
+use Illuminate\Support\Once;
 use Tests\CreatesApplication;
 
 /*
@@ -25,7 +25,7 @@ use Tests\CreatesApplication;
 
 uses(TestCase::class, CreatesApplication::class)
     ->beforeEach(function () {
-        Once\Cache::getInstance()->flush();
+        Once::flush();
 
         (new Filesystem)->deleteDirectory(base_path('tests/.laravel-forge'));
 


### PR DESCRIPTION
## Summary
Upgrades the CLI from Laravel Zero 10 to Laravel Zero 12.

Inspired by #101 by @buzkall -- this is a minimal version focusing only on the changes needed for the upgrade to work.

### Changes
- Bump PHP requirement from `^8.1` to `^8.2`
- Bump `laravel-zero/framework` from `^10.0.2` to `^12.0`
- Bump `larastan/larastan` from `^2.6.0` to `^3.0`
- Bump `pestphp/pest` from `^2.6.1` to `^3.0`
- Remove `spatie/once` (Laravel 11+ includes built-in `Illuminate\Support\Once`)
- Replace `Spatie\Once\Cache::getInstance()->flush()` with `Illuminate\Support\Once::flush()` in `ServerSwitchCommand` and `tests/Pest.php`
- Add `: int` return type to `Command::execute()` (PHP 8.4 deprecation fix)
- Remove deprecated PHPStan config options (`checkMissingIterableValueType`, `checkGenericClassInNonGenericObjectType`)

### What this fixes
- **CI is currently broken on master** -- `composer install` fails due to `spatie/once` + `brianium/paratest` dependency conflicts, which means the test workflow hasn't been running
- **PHP 8.4 deprecation warnings** from missing return type on `Command::execute()`

### What this skips (vs #101)
- No version bump (maintainer decision)
- No PHPStan config additions (`scanDirectories`, `rootDir`, `tmpDir`) -- not needed
- No removal of PHPStan strictness suppressions -- separate concern

## Testing
```bash
composer install
vendor/bin/pest       # 98/102 pass (4 pre-existing DeployCommandTest failures, see #144)
vendor/bin/phpstan    # passes after config update
```

Tested locally on PHP 8.4.18 (WSL/Linux) and PHP 8.4.19 (Windows).

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.