### PR TITLE
[master] [ci] Update test matrix: drop PHP 8.1, add PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
 
     name: PHP ${{ matrix.php }}
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Execute static analysis
         run: vendor/bin/phpstan
-        if: matrix.php == '8.1'
+        if: matrix.php == '8.2'
 
       - name: Execute unit/feature tests
         run: vendor/bin/pest


### PR DESCRIPTION
## Summary
- Drop PHP 8.1 from the test matrix (no longer supported after Laravel Zero 12 upgrade, see #146)
- Add PHP 8.4 to catch deprecation issues
- Move PHPStan to run on PHP 8.2 (the new minimum)

**Note:** This PR depends on #146 (Laravel Zero 12 upgrade) being merged first. The `tests` workflow is currently disabled by GitHub due to inactivity and will need to be re-enabled via **Actions > tests > Enable workflow**.

## Before
```yaml
php: [8.1, 8.2, 8.3]
```

## After
```yaml
php: [8.2, 8.3, 8.4]
```