### PR TITLE
[master] [bug] Fix API token truncation on login

### DIFF
--- a/app/Commands/LoginCommand.php
+++ b/app/Commands/LoginCommand.php
@@ -28,7 +28,7 @@ class LoginCommand extends Command
         $token = $this->option('token');
 
         if ($token === null) {
-            $token = $this->askStep('Please enter your Forge API token');
+            $token = $this->secretStep('Please enter your Forge API token');
         }
 
         $this->config->set('token', $token);


### PR DESCRIPTION
## Summary
The `forge login` prompt uses `askStep` which goes through readline, truncating input at 1024 characters. Forge API tokens are ~2197 characters, causing login to silently fail with a truncated (invalid) token.

This changes `askStep` to `secretStep` which:
1. Bypasses readline (no truncation)
2. Masks the input, which is appropriate since the token is a secret

One line change.

Fixes #127

## Before
```
$ forge login
  ‣ Please Enter Your Forge API Token > eyJ0eXAiOiJKV1Q...  (visible, truncated at 1024 chars)
```

## After
```
$ forge login
  ‣ Please Enter Your Forge API Token >  (hidden, full token accepted)
```

## Testing
```bash
forge login
# Paste a long API token (2197+ chars)
# Should accept the full token and authenticate successfully
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.