### PR TITLE
[master] [bug] Fix crash in ssh:configure when key generation fails

### DIFF
--- a/app/Repositories/KeyRepository.php
+++ b/app/Repositories/KeyRepository.php
@@ -42,6 +42,8 @@ class KeyRepository
 
         $keys = json_decode(exec($basePath.'/scripts/keysFactory.php'), true);
 
+        abort_if(is_null($keys), 1, 'Failed to generate SSH key. Ensure PHP can execute '.$basePath.'/scripts/keysFactory.php');
+
         File::put($this->keysPath.'/'.$this->privateKeyName($name), $keys['private']);
         File::chmod($this->keysPath.'/'.$this->privateKeyName($name), 0600);
 


### PR DESCRIPTION
## Summary
`KeyRepository::create()` calls `keysFactory.php` via `exec()` and `json_decode`s the result without checking for failure. If the subprocess fails (wrong PHP binary, missing dependencies, PHAR path issues), `json_decode` returns null and the subsequent array access crashes with:

```
Trying to access array offset on null
```

This adds an `abort_if` guard with a helpful error message pointing to the script that failed to execute.

Fixes #96

## Before
```
$ forge ssh:configure
  An unexpected error occured.
  - Error Message: Trying to access array offset on null.
```

## After
```
$ forge ssh:configure
  Failed to generate SSH key. Ensure PHP can execute /path/to/scripts/keysFactory.php
```

## Testing
```bash
forge ssh:configure
# If key generation fails, should show a clear error message
# instead of "Trying to access array offset on null"
```

> Note: I don't have a Laravel Forge subscription and was unable to end-to-end test. I currently use Laravel Cloud for my hosting needs instead.